### PR TITLE
Improved tap event + double tap

### DIFF
--- a/interact.js
+++ b/interact.js
@@ -1373,7 +1373,9 @@
             tap[prop] = event[prop];
         }
 
-        tap.preventDefault = blank;
+        tap.preventDefault = function () {
+            this.originalEvent.preventdefault();
+        };
         tap.stopPropagation = InteractEvent.prototype.stopPropagation;
         tap.stopImmediatePropagation = InteractEvent.prototype.stopImmediatePropagation;
 


### PR DESCRIPTION
Touch and mouse `'tap'` event.

``` javascript
// example: fast clicking anchor links on touchscreens
interact('a[href]').on('tap', function (event) {
    window.location.href = event.currentTarget.href;
});

// tap
interact(document.body).on('tap', function (event) {
    /* currentTarget will be the element that the listener was bound to (document.body)
     * target will be the target of the pointer event
     * dt is the time in ms between pointerdown and pointerup */
    console.log(event.type, event.currentTarget, event.target, dt);
});

// doubletap
interact('.double-tap-button').on('doubletap', function (event) {
    // dt of doubletap is the time between the two previous tap events
    console.log(event.type, event.currentTarget, event.target, dt);
});

// tap events bubble. This example will log the tap event
// once for every element that the event bubbles through
interact('*').on('tap', function (event) {
    console.log(event.type, event.currentTarget);
});

// bubbling can be stopped by calling stopPropagation or stopImmediatePropagation
interact('.stop-taps').on('tap', function (event) {
    event.stopPropagation();
    // listeners won't be called for elements above this one
    // event.stopImmediatePropagation() would also prevent further listeners on this element
    // from being called
    console.log('propagation stopped');
});
```
