### PR TITLE
Check if downEvent exists added to collectTaps

### DIFF
--- a/interact.js
+++ b/interact.js
@@ -1429,10 +1429,12 @@
     }
 
     function collectTaps (event) {
-        if (pointerWasMoved
-            || !(event instanceof downEvent.constructor)
-            || downEvent.target !== event.target) {
-            return;
+        if(downEvent) {
+            if (pointerWasMoved
+                || !(event instanceof downEvent.constructor)
+                || downEvent.target !== event.target) {
+                return;
+            }    
         }
 
         var tapTargets = [],


### PR DESCRIPTION
Third-party widgets have been found to consume the event stopping propagation.
