### PR TITLE
Option for snap and restrict to be relative to the element's position and dimentions

### DIFF
--- a/interact.js
+++ b/interact.js
@@ -1052,6 +1052,10 @@
 
         action = action || prepared;
 
+        if (/^resize/.test(action)) {
+            action = 'resize';
+        }
+
         return (options.snapEnabled && indexOf(options.snap.actions, action) !== -1);
     }
 
@@ -1059,6 +1063,10 @@
         var options = interactable.options;
 
         action = action || prepared;
+
+        if (/^resize/.test(action)) {
+            action = 'resize';
+        }
 
         return options.restrictEnabled && options.restrict[action];
     }


### PR DESCRIPTION
## Snap elementOrigin

``` javascript
interact('*').snap({
  elementOrigin: { x: 0, y: 0 }
});
```

elementOrigin.x/y are scalars specifying the position on the element to
which snapping should be relative.

```
{x:   0, y:   0}  is the top left
{x: 0.5, y: 0.5}  is the center
{x:   1, y:   1}  is the bottom right
```
## Restrict elementRect

``` javascript
interact('*').restrict({
  elementRect: { top: 0, left: 0, bottom: 1, right: 1 }
});
```

For the left and right properties, 0 means the very left of the element
and 1 means the very right. For top and bottom, 0 means the top of the
element and 1 means the bottom.

`{ top: 0.25, left: 0.25, bottom: 0.75, right: 0.75 }` would result in a
quarter of the element being allowed to hang over the restriction edges.

Closes #47
Closes #59
