### PR TITLE
Changes to UMD export, Remove IIFE, Change References in demo files

### DIFF
--- a/demo/dropzones.html
+++ b/demo/dropzones.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>Highlight dropzones with interact.js</title>
-    <script src="../interact.js"></script>
+    <script src="../build/interact.js"></script>
     <script src="js/dropzones.js"></script>
     <link rel="stylesheet" href="css/dropzones.css">
 </head>

--- a/demo/events.html
+++ b/demo/events.html
@@ -9,7 +9,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="css/events.css">
         <script type="text/javascript" src="js/underscore-min.js"></script>
-        <script type="text/javascript" src="../interact.js"></script>
+        <script type="text/javascript" src="../build/interact.js"></script>
         <script type="text/javascript" src="js/events.js"></script>
     </head>
     <body>

--- a/demo/gallery.html
+++ b/demo/gallery.html
@@ -88,7 +88,7 @@
 }
 </style>
 
-<script src="../interact.js"></script>
+<script src="../build/interact.js"></script>
 <script src="js/modernizr.js"></script>
 <script src="js/jquery-2.1.0.min.js"></script>
 </head>

--- a/demo/html_svg.html
+++ b/demo/html_svg.html
@@ -5,7 +5,7 @@
 		<title>interact.js demo</title>
 		<meta name="description" content="A small demonstration of interact.js, a drag and drop, resize and multitouch gesture module for modern browsers (and IE8)" />
 		<meta name="author" content="Taye Adeyemi" />
-		<script type="text/javascript" src="../interact.js"></script>
+		<script type="text/javascript" src="../build/interact.js"></script>
 		<script type="text/javascript" src="js/html_svg.js"></script>
 		<link rel="stylesheet" href="css/html_svg.css" type="text/css"/>
 	</head>

--- a/demo/iframes-middle.html
+++ b/demo/iframes-middle.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8">
 <link href="css/iframes.css" rel="stylesheet" type="text/css"/>
 
-<script src="../interact.js"></script>
+<script src="../build/interact.js"></script>
 
 <iframe src="iframes-bottom.html" style="border: solid 2px black"></iframe>
 

--- a/demo/snap.html
+++ b/demo/snap.html
@@ -5,7 +5,7 @@
 <title>interact.js drag snapping</title>
 <meta name="description" content="A demonstration of interact.js drag snapping" />
 <meta name="author" content="Taye Adeyemi" />
-<script type="text/javascript" src="../interact.js"></script>
+<script type="text/javascript" src="../build/interact.js"></script>
 <script type="text/javascript" src="js/snap.js"></script>
 <link rel="stylesheet" href="css/snap.css" type="text/css"/>
 </head>

--- a/src/interact.js
+++ b/src/interact.js
@@ -5,7 +5,7 @@
  * Open source under the MIT License.
  * https://raw.github.com/taye/interact.js/master/LICENSE
  */
-(function () {
+
     'use strict';
 
     // return early if there's no window to work with (eg. Node.js)
@@ -5271,5 +5271,3 @@
     else {
         scope.realWindow.interact = interact;
     }
-
-} ());

--- a/src/interact.js
+++ b/src/interact.js
@@ -5268,6 +5268,6 @@
             return interact;
         });
     }
-    else {
-        scope.realWindow.interact = interact;
-    }
+
+    // always export interact on the global scope
+    scope.realWindow.interact = interact;


### PR DESCRIPTION
* removes IIFE, Browserify now wraps this and protects scope
* Always export interact on the global scope (ie. `window`) …
While typical UMD support is to check for CommonJS, AMD and the only export to window if neither    was detected, since we are using Browserify, CommonJS will come up as a false positive due to the Browserify prelude, resulting in interact not being exported to window for non module users.
* point references to `interact.js` in demo htdocs to `build` folder