### PR TITLE
Fix pointer dt on touchscreen devices

### DIFF
--- a/interact.js
+++ b/interact.js
@@ -2749,7 +2749,7 @@
         },
 
         firePointers: function (pointer, event, eventTarget, targets, elements, eventType) {
-            var pointerIndex = this.mouse? 0 : indexOf(getPointerId(pointer)),
+            var pointerIndex = this.mouse? 0 : indexOf(this.pointerIds, getPointerId(pointer)),
                 pointerEvent = {},
                 i,
                 // for tap events


### PR DESCRIPTION
I think this was forgotten with cc14819, I just realised tap.dt is NaN on touchscreen devices, now it works fine.