### PR TITLE
Consecutive commas in array literal

### DIFF
--- a/interact.js
+++ b/interact.js
@@ -2778,7 +2778,7 @@
                 pointerEvent.pointerType   = this.mouse? 'mouse' : !supportsPointerEvent? 'touch'
                                                     : isString(pointer.pointerType)
                                                         ? pointer.pointerType
-                                                        : [,,'touch', 'pen', 'mouse'][pointer.pointerType];
+                                                        : ['touch', 'pen', 'mouse'][pointer.pointerType];
             }
 
             if (eventType === 'tap') {


### PR DESCRIPTION
Skipped elements take undefined value. Is really that what is supposed to do?