### PR TITLE
add `resizable.preserveAspectRatio` option

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -221,7 +221,7 @@
                       
                       <article id="Interaction.start">
                           <header>
-                              <h3 class="dr-method">Interaction.start(action, interactable, element)<a href="#Interaction.start" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 1715 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L1715">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interaction.start(action, interactable, element)<a href="#Interaction.start" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 1727 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L1727">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interaction.start-extra"></div>
@@ -316,7 +316,7 @@ of pointers must be held down – 1 for drag/resize, 2 for gesture.
                       
                       <article id="interact">
                           <header>
-                              <h3 class="dr-method">interact(element)<a href="#interact" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 3857 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L3857">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact(element)<a href="#interact" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 3889 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L3889">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact-extra"></div>
@@ -420,7 +420,7 @@ rectables
                       
                       <article id="Interactable">
                           <header>
-                              <h3 class="dr-property">Interactable<a href="#Interactable" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 3867 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L3867">&#x27ad;</a></h3>
+                              <h3 class="dr-property">Interactable<a href="#Interactable" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 3899 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L3899">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable-extra"></div>
@@ -445,7 +445,7 @@ rectables
                       
                       <article id="Interactable.draggable">
                           <header>
-                              <h3 class="dr-method">Interactable.draggable([options])<a href="#Interactable.draggable" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 3969 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L3969">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.draggable([options])<a href="#Interactable.draggable" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4001 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4001">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.draggable-extra"></div>
@@ -573,7 +573,7 @@ Interactable
                       
                       <article id="Interactable.dropzone">
                           <header>
-                              <h3 class="dr-method">Interactable.dropzone([options])<a href="#Interactable.dropzone" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4048 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4048">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.dropzone([options])<a href="#Interactable.dropzone" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4080 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4080">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.dropzone-extra"></div>
@@ -662,7 +662,7 @@ Interactable to trigger drop events
                       
                       <article id="Interactable.dropChecker">
                           <header>
-                              <h3 class="dr-method">Interactable.dropChecker(…)<a href="#Interactable.dropChecker" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4165 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4165">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.dropChecker(…)<a href="#Interactable.dropChecker" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4197 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4197">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.dropChecker-extra"></div>
@@ -815,7 +815,7 @@ over this Interactable.
                       
                       <article id="Interactable.accept">
                           <header>
-                              <h3 class="dr-method">Interactable.accept([newValue])<a href="#Interactable.accept" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4197 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4197">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.accept([newValue])<a href="#Interactable.accept" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4229 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4229">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.accept-extra"></div>
@@ -897,7 +897,7 @@ If it is null, the accept options is cleared - it accepts any element.
                       
                       <article id="Interactable.resizable">
                           <header>
-                              <h3 class="dr-method">Interactable.resizable([options])<a href="#Interactable.resizable" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4256 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4256">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.resizable([options])<a href="#Interactable.resizable" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4296 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4296">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.resizable-extra"></div>
@@ -1008,6 +1008,14 @@ Interactable
       right : handleEl    // Resize if pointer target is the given Element
     },
 
+    // Width and height can be adjusted independently. When `true`, width and
+    // height are adjusted at a 1:1 ratio.
+    square: false,
+
+    // Width and height can be adjusted independently. When `true`, width and
+    // height maintain the aspect ratio they had when resizing started.
+    preserveAspectRatio: false,
+
     // a value of 'none' will limit the resize rect to a minimum of 0x0
     // 'negate' will allow the rect to have negative width/height
     // 'reposition' will keep the width/height positive by swapping
@@ -1030,7 +1038,7 @@ Interactable
                       
                       <article id="Interactable.squareResize">
                           <header>
-                              <h3 class="dr-method">Interactable.squareResize([newValue])<a href="#Interactable.squareResize" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4298 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4298">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.squareResize([newValue])<a href="#Interactable.squareResize" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4341 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4341">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.squareResize-extra"></div>
@@ -1119,7 +1127,7 @@ Interactable
                       
                       <article id="Interactable.gesturable">
                           <header>
-                              <h3 class="dr-method">Interactable.gesturable([options])<a href="#Interactable.gesturable" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4337 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4337">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.gesturable([options])<a href="#Interactable.gesturable" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4380 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4380">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.gesturable-extra"></div>
@@ -1239,7 +1247,7 @@ Interactable&#39;s element
                       
                       <article id="Interactable.autoScroll">
                           <header>
-                              <h3 class="dr-method">Interactable.autoScroll([options])<a href="#Interactable.autoScroll" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4375 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4375">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.autoScroll([options])<a href="#Interactable.autoScroll" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4418 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4418">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.autoScroll-extra"></div>
@@ -1343,7 +1351,7 @@ window/container trigger autoScroll for this Interactable
                       
                       <article id="Interactable.snap">
                           <header>
-                              <h3 class="dr-method">Interactable.snap([options])<a href="#Interactable.snap" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4445 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4445">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.snap([options])<a href="#Interactable.snap" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4488 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4488">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.snap-extra"></div>
@@ -1498,7 +1506,7 @@ change this by setting the
                       
                       <article id="Interactable.inertia">
                           <header>
-                              <h3 class="dr-method">Interactable.inertia([options])<a href="#Interactable.inertia" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4562 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4562">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.inertia([options])<a href="#Interactable.inertia" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4605 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4605">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.inertia-extra"></div>
@@ -1643,7 +1651,7 @@ interact(element).inertia(null);</code></pre></section>
                       
                       <article id="Interactable.actionChecker">
                           <header>
-                              <h3 class="dr-method">Interactable.actionChecker([checker])<a href="#Interactable.actionChecker" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4610 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4610">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.actionChecker([checker])<a href="#Interactable.actionChecker" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4653 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4653">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.actionChecker-extra"></div>
@@ -1743,7 +1751,7 @@ pointerDown
                       
                       <article id="Interactable.getRect">
                           <header>
-                              <h3 class="dr-method">Interactable.getRect([element])<a href="#Interactable.getRect" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4644 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4644">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.getRect([element])<a href="#Interactable.getRect" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4687 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4687">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.getRect-extra"></div>
@@ -1848,7 +1856,7 @@ overridden using <a href="#Interactable.rectChecker" class="dr-link">Interactabl
                       
                       <article id="Interactable.rectChecker">
                           <header>
-                              <h3 class="dr-method">Interactable.rectChecker([checker])<a href="#Interactable.rectChecker" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4664 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4664">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.rectChecker([checker])<a href="#Interactable.rectChecker" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4707 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4707">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.rectChecker-extra"></div>
@@ -1911,7 +1919,7 @@ element&#39;s rectangle
                       
                       <article id="Interactable.styleCursor">
                           <header>
-                              <h3 class="dr-method">Interactable.styleCursor([newValue])<a href="#Interactable.styleCursor" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4691 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4691">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.styleCursor([newValue])<a href="#Interactable.styleCursor" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4734 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4734">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.styleCursor-extra"></div>
@@ -1975,7 +1983,7 @@ may be styled appropriately
                       
                       <article id="Interactable.preventDefault">
                           <header>
-                              <h3 class="dr-method">Interactable.preventDefault([newValue])<a href="#Interactable.preventDefault" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4720 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4720">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.preventDefault([newValue])<a href="#Interactable.preventDefault" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4763 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4763">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.preventDefault-extra"></div>
@@ -2041,7 +2049,7 @@ in response to pointer events. Can be set to:
                       
                       <article id="Interactable.origin">
                           <header>
-                              <h3 class="dr-method">Interactable.origin(…)<a href="#Interactable.origin" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4747 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4747">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.origin(…)<a href="#Interactable.origin" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4790 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4790">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.origin-extra"></div>
@@ -2131,7 +2139,7 @@ of the origin will be subtracted from action event coordinates.
                       
                       <article id="Interactable.deltaSource">
                           <header>
-                              <h3 class="dr-method">Interactable.deltaSource([newValue])<a href="#Interactable.deltaSource" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4770 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4770">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.deltaSource([newValue])<a href="#Interactable.deltaSource" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4813 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4813">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.deltaSource-extra"></div>
@@ -2194,7 +2202,7 @@ movement of the pointer.
                       
                       <article id="Interactable.restrict">
                           <header>
-                              <h3 class="dr-method">Interactable.restrict([options])<a href="#Interactable.restrict" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4817 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4817">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.restrict([options])<a href="#Interactable.restrict" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4860 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4860">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.restrict-extra"></div>
@@ -2290,7 +2298,7 @@ interact('.draggable').restrict({
                       
                       <article id="Interactable.context">
                           <header>
-                              <h3 class="dr-method">Interactable.context()<a href="#Interactable.context" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4850 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4850">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.context()<a href="#Interactable.context" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4893 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4893">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.context-extra"></div>
@@ -2332,7 +2340,7 @@ interact('.draggable').restrict({
                       
                       <article id="Interactable.ignoreFrom">
                           <header>
-                              <h3 class="dr-method">Interactable.ignoreFrom([newValue])<a href="#Interactable.ignoreFrom" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4871 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4871">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.ignoreFrom([newValue])<a href="#Interactable.ignoreFrom" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4914 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4914">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.ignoreFrom-extra"></div>
@@ -2411,7 +2419,7 @@ interact(element).ignoreFrom('input, textarea, a');</code></pre></section>
                       
                       <article id="Interactable.allowFrom">
                           <header>
-                              <h3 class="dr-method">Interactable.allowFrom([newValue])<a href="#Interactable.allowFrom" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4900 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4900">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.allowFrom([newValue])<a href="#Interactable.allowFrom" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4943 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4943">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.allowFrom-extra"></div>
@@ -2490,7 +2498,7 @@ interact(element).allowFrom('.handle');</code></pre></section>
                       
                       <article id="Interactable.element">
                           <header>
-                              <h3 class="dr-method">Interactable.element()<a href="#Interactable.element" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4923 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4923">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.element()<a href="#Interactable.element" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4966 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4966">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.element-extra"></div>
@@ -2533,7 +2541,7 @@ interactable represents
                       
                       <article id="Interactable.fire">
                           <header>
-                              <h3 class="dr-method">Interactable.fire(iEvent)<a href="#Interactable.fire" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4937 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4937">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.fire(iEvent)<a href="#Interactable.fire" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4980 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4980">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.fire-extra"></div>
@@ -2594,7 +2602,7 @@ and directly to this Interactable
                       
                       <article id="Interactable.on">
                           <header>
-                              <h3 class="dr-method">Interactable.on(eventType, listener, [useCapture])<a href="#Interactable.on" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4987 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L4987">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.on(eventType, listener, [useCapture])<a href="#Interactable.on" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5030 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5030">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.on-extra"></div>
@@ -2660,7 +2668,7 @@ and directly to this Interactable
                       
                       <article id="Interactable.off">
                           <header>
-                              <h3 class="dr-method">Interactable.off(eventType, listener, [useCapture])<a href="#Interactable.off" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5081 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5081">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.off(eventType, listener, [useCapture])<a href="#Interactable.off" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5124 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5124">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.off-extra"></div>
@@ -2726,7 +2734,7 @@ and directly to this Interactable
                       
                       <article id="Interactable.set">
                           <header>
-                              <h3 class="dr-method">Interactable.set(options)<a href="#Interactable.set" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5190 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5190">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.set(options)<a href="#Interactable.set" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5233 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5233">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.set-extra"></div>
@@ -2786,7 +2794,7 @@ and directly to this Interactable
                       
                       <article id="Interactable.unset">
                           <header>
-                              <h3 class="dr-method">Interactable.unset()<a href="#Interactable.unset" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5240 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5240">&#x27ad;</a></h3>
+                              <h3 class="dr-method">Interactable.unset()<a href="#Interactable.unset" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5283 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5283">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="Interactable.unset-extra"></div>
@@ -2829,7 +2837,7 @@ it&#39;s drag, drop, resize and gesture capabilities
                       
                       <article id="interact.isSet">
                           <header>
-                              <h3 class="dr-method">interact.isSet(element)<a href="#interact.isSet" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5323 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5323">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.isSet(element)<a href="#interact.isSet" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5366 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5366">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.isSet-extra"></div>
@@ -2889,7 +2897,7 @@ it&#39;s drag, drop, resize and gesture capabilities
                       
                       <article id="interact.on">
                           <header>
-                              <h3 class="dr-method">interact.on(type, listener, [useCapture])<a href="#interact.on" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5339 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5339">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.on(type, listener, [useCapture])<a href="#interact.on" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5382 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5382">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.on-extra"></div>
@@ -2956,7 +2964,7 @@ it&#39;s drag, drop, resize and gesture capabilities
                       
                       <article id="interact.off">
                           <header>
-                              <h3 class="dr-method">interact.off(type, listener, [useCapture])<a href="#interact.off" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5389 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5389">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.off(type, listener, [useCapture])<a href="#interact.off" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5432 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5432">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.off-extra"></div>
@@ -3022,7 +3030,7 @@ it&#39;s drag, drop, resize and gesture capabilities
                       
                       <article id="interact.enableDragging">
                           <header>
-                              <h3 class="dr-method">interact.enableDragging([newValue])<a href="#interact.enableDragging" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5436 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5436">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.enableDragging([newValue])<a href="#interact.enableDragging" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5479 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5479">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.enableDragging-extra"></div>
@@ -3085,7 +3093,7 @@ it&#39;s drag, drop, resize and gesture capabilities
                       
                       <article id="interact.enableResizing">
                           <header>
-                              <h3 class="dr-method">interact.enableResizing([newValue])<a href="#interact.enableResizing" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5456 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5456">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.enableResizing([newValue])<a href="#interact.enableResizing" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5499 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5499">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.enableResizing-extra"></div>
@@ -3148,7 +3156,7 @@ it&#39;s drag, drop, resize and gesture capabilities
                       
                       <article id="interact.enableGesturing">
                           <header>
-                              <h3 class="dr-method">interact.enableGesturing([newValue])<a href="#interact.enableGesturing" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5476 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5476">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.enableGesturing([newValue])<a href="#interact.enableGesturing" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5519 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5519">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.enableGesturing-extra"></div>
@@ -3211,7 +3219,7 @@ it&#39;s drag, drop, resize and gesture capabilities
                       
                       <article id="interact.debug">
                           <header>
-                              <h3 class="dr-method">interact.debug()<a href="#interact.debug" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5494 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5494">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.debug()<a href="#interact.debug" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5537 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5537">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.debug-extra"></div>
@@ -3253,7 +3261,7 @@ it&#39;s drag, drop, resize and gesture capabilities
                       
                       <article id="interact.margin">
                           <header>
-                              <h3 class="dr-method">interact.margin([newValue])<a href="#interact.margin" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5570 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5570">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.margin([newValue])<a href="#interact.margin" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5616 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5616">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.margin-extra"></div>
@@ -3262,7 +3270,8 @@ it&#39;s drag, drop, resize and gesture capabilities
                                   
                                   
                                   
-                                  <p></p><p>Returns or sets the margin for autocheck resizing used in
+                                  <p></p><p>Deprecated. Use <code>interact(target).resizable({ margin: number });</code> instead.
+Returns or sets the margin for autocheck resizing used in
 <a href="#Interactable.getAction" class="dr-link">Interactable.getAction</a>. That is the distance from the bottom and right
 edges of an element clicking in which will start resizing
 </p><p></p>
@@ -3317,7 +3326,7 @@ edges of an element clicking in which will start resizing
                       
                       <article id="interact.supportsTouch">
                           <header>
-                              <h3 class="dr-method">interact.supportsTouch()<a href="#interact.supportsTouch" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5585 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5585">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.supportsTouch()<a href="#interact.supportsTouch" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5632 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5632">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.supportsTouch-extra"></div>
@@ -3358,7 +3367,7 @@ edges of an element clicking in which will start resizing
                       
                       <article id="interact.supportsPointerEvent">
                           <header>
-                              <h3 class="dr-method">interact.supportsPointerEvent()<a href="#interact.supportsPointerEvent" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5595 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5595">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.supportsPointerEvent()<a href="#interact.supportsPointerEvent" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5642 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5642">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.supportsPointerEvent-extra"></div>
@@ -3399,7 +3408,7 @@ edges of an element clicking in which will start resizing
                       
                       <article id="interact.stop">
                           <header>
-                              <h3 class="dr-method">interact.stop(event)<a href="#interact.stop" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5608 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5608">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.stop(event)<a href="#interact.stop" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5655 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5655">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.stop-extra"></div>
@@ -3459,7 +3468,7 @@ edges of an element clicking in which will start resizing
                       
                       <article id="interact.dynamicDrop">
                           <header>
-                              <h3 class="dr-method">interact.dynamicDrop([newValue])<a href="#interact.dynamicDrop" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5627 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5627">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.dynamicDrop([newValue])<a href="#interact.dynamicDrop" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5674 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5674">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.dynamicDrop-extra"></div>
@@ -3523,7 +3532,7 @@ dropChecker
                       
                       <article id="interact.pointerMoveTolerance">
                           <header>
-                              <h3 class="dr-method">interact.pointerMoveTolerance([newValue])<a href="#interact.pointerMoveTolerance" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5649 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5649">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.pointerMoveTolerance([newValue])<a href="#interact.pointerMoveTolerance" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5696 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5696">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.pointerMoveTolerance-extra"></div>
@@ -3586,7 +3595,7 @@ sequence occurs. This also affects tolerance for tap events.
                       
                       <article id="interact.maxInteractions">
                           <header>
-                              <h3 class="dr-method">interact.maxInteractions([newValue])<a href="#interact.maxInteractions" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5671 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5671">&#x27ad;</a></h3>
+                              <h3 class="dr-method">interact.maxInteractions([newValue])<a href="#interact.maxInteractions" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 5718 in the source" href="https://github.com/taye/interact.js/blob/v1.2.5/interact.js#L5718">&#x27ad;</a></h3>
                           </header>
                           <section>
                               <div class="extra" id="interact.maxInteractions-extra"></div>

--- a/interact.js
+++ b/interact.js
@@ -104,6 +104,7 @@
                 autoScroll: null,
 
                 square: false,
+                preserveAspectRatio: false,
                 axis: 'xy',
 
                 // use default margin
@@ -1980,18 +1981,29 @@
             if (this.prepared.edges) {
                 var startRect = this.target.getRect(this.element);
 
-                if (this.target.options.resize.square) {
-                    var squareEdges = extend({}, this.prepared.edges);
+                /*
+                 * When using the `resizable.square` or `resizable.preserveAspectRatio` options, resizing from one edge
+                 * will affect another. E.g. with `resizable.square`, resizing to make the right edge larger will make
+                 * the bottom edge larger by the same amount. We call these 'linked' edges. Any linked edges will depend
+                 * on the active edges and the edge being interacted with.
+                 */
+                if (this.target.options.resize.square || this.target.options.resize.preserveAspectRatio) {
+                    var linkedEdges = extend({}, this.prepared.edges);
 
-                    squareEdges.top    = squareEdges.top    || (squareEdges.left   && !squareEdges.bottom);
-                    squareEdges.left   = squareEdges.left   || (squareEdges.top    && !squareEdges.right );
-                    squareEdges.bottom = squareEdges.bottom || (squareEdges.right  && !squareEdges.top   );
-                    squareEdges.right  = squareEdges.right  || (squareEdges.bottom && !squareEdges.left  );
+                    linkedEdges.top    = linkedEdges.top    || (linkedEdges.left   && !linkedEdges.bottom);
+                    linkedEdges.left   = linkedEdges.left   || (linkedEdges.top    && !linkedEdges.right );
+                    linkedEdges.bottom = linkedEdges.bottom || (linkedEdges.right  && !linkedEdges.top   );
+                    linkedEdges.right  = linkedEdges.right  || (linkedEdges.bottom && !linkedEdges.left  );
 
-                    this.prepared._squareEdges = squareEdges;
+                    this.prepared._linkedEdges = linkedEdges;
                 }
                 else {
-                    this.prepared._squareEdges = null;
+                    this.prepared._linkedEdges = null;
+                }
+
+                // if using `resizable.preserveAspectRatio` option, record aspect ratio at the start of the resize
+                if (this.target.options.resize.preserveAspectRatio) {
+                    this.resizeStartAspectRatio = startRect.width / startRect.height;
                 }
 
                 this.resizeRects = {
@@ -2031,12 +2043,25 @@
                     current    = this.resizeRects.current,
                     restricted = this.resizeRects.restricted,
                     delta      = this.resizeRects.delta,
-                    previous   = extend(this.resizeRects.previous, restricted);
+                    previous   = extend(this.resizeRects.previous, restricted),
 
-                if (this.target.options.resize.square) {
-                    var originalEdges = edges;
+                    originalEdges = edges;
 
-                    edges = this.prepared._squareEdges;
+                // `resize.preserveAspectRatio` takes precedence over `resize.square`
+                if (this.target.options.resize.preserveAspectRatio) {
+                    var resizeStartAspectRatio = this.resizeStartAspectRatio;
+
+                    edges = this.prepared._linkedEdges;
+
+                    if ((originalEdges.left && originalEdges.bottom)
+                        || (originalEdges.right && originalEdges.top)) {
+                        dy = -dx / resizeStartAspectRatio;
+                    }
+                    else if (originalEdges.left || originalEdges.right) { dy = dx / resizeStartAspectRatio; }
+                    else if (originalEdges.top || originalEdges.bottom) { dx = dy * resizeStartAspectRatio; }
+                }
+                else if (this.target.options.resize.square) {
+                    edges = this.prepared._linkedEdges;
 
                     if ((originalEdges.left && originalEdges.bottom)
                         || (originalEdges.right && originalEdges.top)) {
@@ -4248,6 +4273,14 @@
          |       right : handleEl    // Resize if pointer target is the given Element
          |     },
          |
+         |     // Width and height can be adjusted independently. When `true`, width and
+         |     // height are adjusted at a 1:1 ratio.
+         |     square: false,
+         |
+         |     // Width and height can be adjusted independently. When `true`, width and
+         |     // height maintain the aspect ratio they had when resizing started.
+         |     preserveAspectRatio: false,
+         |
          |     // a value of 'none' will limit the resize rect to a minimum of 0x0
          |     // 'negate' will allow the rect to have negative width/height
          |     // 'reposition' will keep the width/height positive by swapping
@@ -4273,7 +4306,10 @@
                     this.options.resize.axis = defaultOptions.resize.axis;
                 }
 
-                if (isBool(options.square)) {
+                if (isBool(options.preserveAspectRatio)) {
+                    this.options.resize.preserveAspectRatio = options.preserveAspectRatio;
+                }
+                else if (isBool(options.square)) {
                     this.options.resize.square = options.square;
                 }
 


### PR DESCRIPTION
This maintains the aspect ratio of the interactable as it was at `resizeStart`.

I tested this by modifying the `html_svg` demo and:
-  Adding `preserveAspectRatio: true` to the `resizable` options.
-  Changing the `DemoNode`'s width to `100px` (to give it a 1:2 aspect ratio, which is a bit different to that after the margin, border and padding are added).
-  Changing the `parseInt`s to `parseFloat`s so that rounding doesn't mess up the adjustments.
  wasn't sure if you wanted me to add a demo or test somewhere. I build the docs using dr.js, but the page that lists all the demos seems to be missing (not in the repo, I guess). Also most of the existing tests didn't seem to be working.

It is possible to upset the ratio by externally changing the width and height. E.g. the demo page sets a minimum width/height that will cause the ratio to be upset. I figure the onus for this is on the user.

As per `resizable.square`, resizing from e.g. the bottom right corner is actually an interaction with the right edge (with the bottom edge being linked during the resize), rather than a combination of both edges (i.e. moving up and down will not affect the size, only left and right).

Resolves #169.
