### PR TITLE
Fix calculation of angle, Change which finger is the origin when calc…

### DIFF
--- a/src/utils/pointerUtils.js
+++ b/src/utils/pointerUtils.js
@@ -203,27 +203,9 @@ const pointerUtils = {
     const sourceX = deltaSource + 'X';
     const sourceY = deltaSource + 'Y';
     const touches = pointerUtils.getTouchPair(event);
-    const dx = touches[0][sourceX] - touches[1][sourceX];
-    const dy = touches[0][sourceY] - touches[1][sourceY];
-    let angle = 180 * Math.atan(dy / dx) / Math.PI;
-
-    if (isType.isNumber(prevAngle)) {
-      const dr = angle - prevAngle;
-      const drClamped = dr % 360;
-
-      if (drClamped > 315) {
-        angle -= 360 + (angle / 360)|0 * 360;
-      }
-      else if (drClamped > 135) {
-        angle -= 180 + (angle / 360)|0 * 360;
-      }
-      else if (drClamped < -315) {
-        angle += 360 + (angle / 360)|0 * 360;
-      }
-      else if (drClamped < -135) {
-        angle += 180 + (angle / 360)|0 * 360;
-      }
-    }
+    const dx = touches[1][sourceX] - touches[0][sourceX];
+    const dy = touches[1][sourceY] - touches[0][sourceY];
+    let angle = 180 * Math.atan2(dy , dx) / Math.PI;
 
     return  angle;
   },


### PR DESCRIPTION
…ulating the angle.

Calculate the angle using atan2 instead of atan. This lets the angle cover the full circle and be used in
downstream calculations.

Calculate the angle from the first finger placed to the second, rather than the reverse as previously done.
This is important to the user when they use a finger from each hand for large rotations in rotate-scale
operations.