### PR TITLE
Improve iframe support

### DIFF
--- a/src/Interactable.js
+++ b/src/Interactable.js
@@ -52,12 +52,7 @@ class Interactable {
       win: _window,
     });
 
-    if (this._doc !== scope.document) {
-      scope.signals.fire('listen-to-document', {
-        doc: this._doc,
-        win: _window,
-      });
-    }
+    scope.addDocument( this._doc, _window );
 
     scope.interactables.push(this);
 

--- a/src/interact.js
+++ b/src/interact.js
@@ -362,6 +362,9 @@ interact.maxInteractions = function (newValue) {
   return scope.maxInteractions;
 };
 
+interact.addDocument    = scope.addDocument;
+interact.removeDocument = scope.removeDocument;
+
 scope.interact = interact;
 
 module.exports = interact;

--- a/src/legacyBrowsers.js
+++ b/src/legacyBrowsers.js
@@ -40,20 +40,28 @@ function onIE8Dblclick (event) {
 }
 
 if (browser.isIE8) {
-  scope.signals.on('listen-to-document', function ({ doc }) {
-    // For IE's lack of Event#preventDefault
-    events.add(doc, 'selectstart', function (event) {
-      for (const interaction of scope.interactions) {
-        if (interaction.interacting()) {
-          interaction.checkAndPreventDefault(event);
-        }
+  const selectFix = function (event) {
+    for (const interaction of scope.interactions) {
+      if (interaction.interacting()) {
+        interaction.checkAndPreventDefault(event);
       }
-    });
+    }
+  };
+
+  const onDocIE8 = function onDocIE8 ({ doc, win }, signalName) {
+    const eventMethod = signalName.indexOf('listen') === 0
+      ? events.add : events.remove;
+
+    // For IE's lack of Event#preventDefault
+    eventMethod(doc, 'selectstart', selectFix);
 
     if (scope.pointerEvents) {
-      events.add(doc, 'dblclick', onIE8Dblclick);
+      eventMethod(doc, 'dblclick', onIE8Dblclick);
     }
-  });
+  };
+
+  scope.signals.on('add-document'   , onDocIE8);
+  scope.signals.on('remove-document', onDocIE8);
 }
 
 module.exports = null;

--- a/src/scope.js
+++ b/src/scope.js
@@ -1,11 +1,11 @@
 const scope   = {};
 const utils   = require('./utils');
+const events  = require('./utils/events');
 const signals = require('./utils/Signals').new();
 
 scope.defaultOptions = require('./defaultOptions');
-scope.events         = require('./utils/events');
-
 scope.signals        = signals;
+scope.events         = events;
 
 utils.extend(scope, require('./utils/window'));
 utils.extend(scope, require('./utils/domObjects'));
@@ -61,12 +61,41 @@ scope.endAllInteractions = function (event) {
 
 scope.prefixedPropREs = utils.prefixedPropREs;
 
-scope.signals.on('listen-to-document', function ({ doc }) {
-  // if document is already known
-  if (utils.contains(scope.documents, doc)) {
-    // don't call any further signal listeners
-    return false;
+scope.addDocument = function (doc, win) {
+  // do nothing if document is already known
+  if (utils.contains(scope.documents, doc)) { return false; }
+
+  win = win || scope.getWindow(doc);
+
+  scope.documents.push(doc);
+  events.documents.push(doc);
+
+  // don't add an unload event for the main document
+  // so that the page may be cached in browser history
+  if (doc !== scope.document) {
+    events.add(win, 'unload', scope.onWindowUnload);
   }
-});
+
+  signals.fire('add-document', { doc, win });
+};
+
+scope.removeDocument = function (doc, win) {
+  const index = utils.indexOf(scope.documents, doc);
+
+  if (index === -1) { return false; }
+
+  win = win || scope.getWindow(doc);
+
+  events.remove(win, 'unload', scope.onWindowUnload);
+
+  scope.documents.splice(index, 1);
+  events.documents.splice(index, 1);
+
+  signals.fire('remove-document', { win, doc });
+};
+
+scope.onWindowUnload = function () {
+  scope.removeDocument(this.document, this);
+};
 
 module.exports = scope;


### PR DESCRIPTION
Event listeners are no longer automatically added to the parent window if the script is loaded in an iframe with a parent of the same origin to avoid [potential memory leaks](#311). `preventDefault` is no longer called on `down` events with the `'auto'` setting. This allows mouse move and up events to be fired on the iframe even when the mouse is dragged outside the iframe borders and over the parent document.

`interact.addDocument(document)` and `interact.removeDocument(document)` methods have been added to allow listening to different documents, e.g:

```javascript
// try to listen to events on the parent document if this is an iframe
try {
  if (window.frameElement) {
    const parentDoc = window.frameElement.ownerDocument;
    const parentWindow = parentDoc.defaultView;

    interact.addDocument(parentDoc);
    parentWindow.addEventListener('unload', function () { interact.removeDocument(parentDoc); });
  }
}
catch (error) {}
```

Close #311
Close #312