### PR TITLE
fix typos

### DIFF
--- a/src/Eventable.js
+++ b/src/Eventable.js
@@ -36,11 +36,11 @@ class Eventable {
 
   on (eventType, listener) {
     // if this type of event was never bound
-    if (!(eventType in this)) {
-      this[eventType] = [listener];
+    if (this[eventType]) {
+      this[eventType].push(listener);
     }
     else {
-      this[eventType].push(listener);
+      this[eventType] = [listener];
     }
   }
 
@@ -50,7 +50,11 @@ class Eventable {
     const index     = eventList? indexOf(eventList, listener) : -1;
 
     if (index !== -1) {
-      this[eventType].splice(index, 1);
+      eventList.splice(index, 1);
+    }
+    let undef;
+    if (eventList && eventList.length === 0 || undef === listener) {
+      this[eventType] = undef;
     }
   }
 }

--- a/src/Interactable.js
+++ b/src/Interactable.js
@@ -299,7 +299,7 @@ class Interactable {
 
     // if it is an action event type
     if (contains(Interactable.eventTypes, eventType)) {
-      this.events.on(eventType, listener);
+      this.events.off(eventType, listener);
     }
     // delegated event
     else if (isType.isString(this.target)) {

--- a/src/autoStart/index.js
+++ b/src/autoStart/index.js
@@ -186,7 +186,6 @@ Interaction.signals.on('stop', function ({ interaction }) {
   }
 });
 
-<<<<<<< Updated upstream
 Interactable.prototype.getAction = function (pointer, event, interaction, element) {
   const action = this.defaultActionChecker(pointer, event, interaction, element);
 
@@ -293,8 +292,6 @@ Interactable.prototype.defaultActionChecker = function (pointer, event, interact
   }
 };
 
-=======
->>>>>>> Stashed changes
 function withinInteractionLimit (interactable, element, action) {
   const options = interactable.options;
   const maxActions = options[action.name].max;


### PR DESCRIPTION
fix a typo of git message and another one mentioned in #459:
> can't stop the move event L37 (`e.interactable.off('move');`)

There're 2 reasons making it fail, and one of them is a typo in `Interactable.js` and is fixed by the second commit in this PR.

Another one is that @emilkarl passed only one argument `"move"` to `e.interactable.off` at L37, so the third commit is added to make this usage work.