### PR TITLE
Fix wrong directory in Rails Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installation
 * [npm](https://www.npmjs.org/): `npm install interactjs`
 * Direct download the latest version: http://interactjs.io/#download
   * **Rails 4** app development (using Rails Asset Pipeline)
-    * Download the file interact.js (development version) into a new sub-directory: app/vendor/assets/javascripts/interact
+    * Download the file interact.js (development version) into a new sub-directory: vendor/assets/javascripts/interact
     * Add ```//= require interact/interact``` in app/assets/javascripts/application.js (above ```//= require_tree .```)
     * Restart the Rails server
 * [jsDelivr CDN](http://www.jsdelivr.com/#!interact.js): `<script src="//cdn.jsdelivr.net/interact.js/1.2.6/interact.min.js"></script>`


### PR DESCRIPTION
Sub-directory should be `vendor/assets/javascripts/interact` not `app/vendor/assets/javascripts/interact`. See [Asset Organization for Rails 4](http://guides.rubyonrails.org/v4.0.8/asset_pipeline.html#asset-organization) for proper asset directories.
