### PR TITLE
modifiers/restrict: fix restrictSize, restrictEdges

### DIFF
--- a/src/modifiers/restrict.js
+++ b/src/modifiers/restrict.js
@@ -95,7 +95,11 @@ const restrict = {
 };
 
 function getRestrictionRect (value, interaction, page) {
-  return utils.resolveRectLike(value, interaction.target, interaction.element, [page.x, page.y, interaction]);
+  if (utils.is.function(value)) {
+    return utils.resolveRectLike(value, interaction.target, interaction.element, [page.x, page.y, interaction]);
+  } else {
+    return utils.resolveRectLike(value, interaction.target, interaction.element);
+  }
 }
 
 modifiers.restrict = restrict;

--- a/src/modifiers/restrictEdges.js
+++ b/src/modifiers/restrictEdges.js
@@ -58,8 +58,8 @@ const restrictEdges = {
     const page = status.useStatusXY
       ? { x: status.x, y: status.y }
       : utils.extend({}, pageCoords);
-    const inner = rectUtils.xywhToTlbr(getRestrictionRect(options.inner, interaction), page) || noInner;
-    const outer = rectUtils.xywhToTlbr(getRestrictionRect(options.outer, interaction), page) || noOuter;
+    const inner = rectUtils.xywhToTlbr(getRestrictionRect(options.inner, interaction, page)) || noInner;
+    const outer = rectUtils.xywhToTlbr(getRestrictionRect(options.outer, interaction, page)) || noOuter;
 
     let modifiedX = page.x;
     let modifiedY = page.y;
@@ -111,6 +111,7 @@ const restrictEdges = {
 
   noInner,
   noOuter,
+  getRestrictionRect,
 };
 
 modifiers.restrictEdges = restrictEdges;

--- a/src/modifiers/restrictSize.js
+++ b/src/modifiers/restrictSize.js
@@ -47,28 +47,28 @@ const restrictSize = {
     arg.options = {
       enabled: options.enabled,
       endOnly: options.endOnly,
-      min: utils.extend({}, restrictEdges.noMin),
-      max: utils.extend({}, restrictEdges.noMax),
+      inner: utils.extend({}, restrictEdges.noInner),
+      outer: utils.extend({}, restrictEdges.noOuter),
     };
 
     if (edges.top) {
-      arg.options.min.top = rect.bottom - maxSize.height;
-      arg.options.max.top = rect.bottom - minSize.height;
+      arg.options.inner.top = rect.bottom - minSize.height;
+      arg.options.outer.top = rect.bottom - maxSize.height;
     }
     else if (edges.bottom) {
-      arg.options.min.bottom = rect.top + minSize.height;
-      arg.options.max.bottom = rect.top + maxSize.height;
+      arg.options.inner.bottom = rect.top + minSize.height;
+      arg.options.outer.bottom = rect.top + maxSize.height;
     }
     if (edges.left) {
-      arg.options.min.left = rect.right - maxSize.width;
-      arg.options.max.left = rect.right - minSize.width;
+      arg.options.inner.left = rect.right - minSize.width;
+      arg.options.outer.left = rect.right - maxSize.width;
     }
     else if (edges.right) {
-      arg.options.min.right = rect.left + minSize.width;
-      arg.options.max.right = rect.left + maxSize.width;
+      arg.options.inner.right = rect.left + minSize.width;
+      arg.options.outer.right = rect.left + maxSize.width;
     }
 
-    return restrictEdges.set(arg);
+    restrictEdges.set(arg);
   },
 
   modifyCoords: restrictEdges.modifyCoords,

--- a/tests/actions/base.js
+++ b/tests/actions/base.js
@@ -18,7 +18,7 @@ test('firePrepared function', t => {
   const interaction = new Interaction();
   const element = {};
   const interactable = new Interactable(element, { origin: { x: 0, y: 0 } });
-  const action = { name: 'TEST' };
+  const action = { name: 'resize' };
   const phase = 'TEST_PHASE';
 
   let event = null;

--- a/tests/actions/drag.js
+++ b/tests/actions/drag.js
@@ -63,10 +63,15 @@ test('Interactable.draggable method', t => {
 
 test('drag axis', t => {
   const Interaction   = require('../../src/Interaction');
+  const Interactable = require('../../src/Interactable');
   const InteractEvent = require('../../src/InteractEvent');
 
   const opposites = { x: 'y', y: 'x' };
   const interaction = new Interaction();
+  const element = {};
+  const interactable = new Interactable(element, { origin: { x: 0, y: 0 } });
+  interaction.target = interactable;
+
   const iEvent = { type: 'dragmove' };
   const eventCoords = {
     pageX:   -1, pageY:   -2,

--- a/tests/index.js
+++ b/tests/index.js
@@ -15,6 +15,7 @@ require('./pointerEvents/holdRepeat');
 // modifiers
 //require('./modifiers/snap');
 //require('./modifiers/restrict');
+require('./modifiers/restrictSize');
 
 // delay
 //require('./autoStart/delay');

--- a/tests/modifiers/restrictSize.js
+++ b/tests/modifiers/restrictSize.js
@@ -1,0 +1,61 @@
+const test = require('../test');
+
+test('restrictSize', t => {
+  const RestrictSize = require('../../src/modifiers/restrictSize');
+  const Interaction = require('../../src/Interaction');
+
+  const interaction = new Interaction();
+  interaction.prepared = {};
+  interaction.prepared.edges = { top: true, bottom: true, left: true, right: true };
+  interaction.resizeRects = {};
+  interaction.resizeRects.inverted = { x: 10, y: 20, width: 300, height: 200 };
+  interaction._interacting = true;
+
+  t.test('works with min and max options', tt => {
+    const options = {
+      min: { width:  60, height:  50 },
+      max: { width: 600, height: 500 },
+    };
+    const status = {};
+    const pageCoords = { x: 5, y: 15 };
+    const offset = { top: 0, bottom: 0, left: 0, right: 0 };
+    const arg = { interaction, options, status, pageCoords, offset };
+
+    RestrictSize.set(arg);
+    tt.deepEqual(arg.options.inner, { top: 170, left: 250, bottom: -Infinity, right: -Infinity });
+    tt.deepEqual(arg.options.outer, { top: -280, left: -290, bottom: Infinity, right: Infinity });
+    tt.end();
+  });
+
+  t.test('works with min option only', tt => {
+    const options = {
+      min: { width: 60, height: 50 },
+    };
+    const status = {};
+    const pageCoords = { x: 5, y: 15 };
+    const offset = { top: 0, bottom: 0, left: 0, right: 0 };
+    const arg = { interaction, options, status, pageCoords, offset };
+
+    RestrictSize.set(arg);
+    tt.deepEqual(arg.options.inner, { top:       170, left:       250, bottom: -Infinity, right: -Infinity });
+    tt.deepEqual(arg.options.outer, { top: -Infinity, left: -Infinity, bottom:  Infinity, right:  Infinity });
+    tt.end();
+  });
+
+  t.test('works with max option only', tt => {
+    const options = {
+      max: { width: 600, height: 500 },
+    };
+    const status = {};
+    const pageCoords = { x: 5, y: 15 };
+    const offset = { top: 0, bottom: 0, left: 0, right: 0 };
+    const arg = { interaction, options, status, pageCoords, offset };
+
+    RestrictSize.set(arg);
+    tt.deepEqual(arg.options.inner, { top: Infinity, left: Infinity, bottom: -Infinity, right: -Infinity });
+    tt.deepEqual(arg.options.outer, { top: -280, left: -290, bottom: Infinity, right: Infinity });
+    tt.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
* Don't require page arguments if they won't be used.
* Update restrictSize to use inner/outer syntax.
* Fix a syntax error in restrictEdges (`page` should be an argument to `getRestrictionRect`).

Fixes #507 

Edit 2: Behavior fixed, tests updated with correct expectations.

Edit 3: Just found what seems to be another issue where the `restrictSize` option value seems to be shared between multiple interactables. Mentioning in case it makes sense to address as part of this PR.