### PR TITLE
Remove redundant dragmove fired

### DIFF
--- a/src/actions/drop.js
+++ b/src/actions/drop.js
@@ -256,7 +256,6 @@ function fireDropEvents (interaction, dropEvents) {
   if (dropEvents.move ) {     interaction.dropTarget.fire(dropEvents.move ); }
   if (dropEvents.enter) {     interaction.dropTarget.fire(dropEvents.enter); }
   if (dropEvents.drop ) {     interaction.dropTarget.fire(dropEvents.drop ); }
-  if (dropEvents.move ) {     interaction.dropTarget.fire(dropEvents.move ); }
   if (dropEvents.deactivate) {
     fireActiveDrops(interaction, dropEvents.deactivate);
   }


### PR DESCRIPTION
I think there is one line of if statement is redundant in the drop file of drag move event.
