### PR TITLE
Fix the TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Gaspard Bucher <feature-space.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare module "interact.js/interact" {
+declare namespace interact {
   interface Position {
     x: number
     y: number
@@ -280,13 +280,13 @@ declare module "interact.js/interact" {
     context: DOMElement
   }
 
-  interface interact {
+  interface InteractStatic {
     ( el: DOMElement | CSSSelector, opts?: InteractOptions ): Interactable
     on ( opt: OnEvent | OnEventFunctions, listener?: Listener ) : Interactable
     supportsTouch () : boolean
     supportsPointerEvent () : boolean
-    stop ( event: any ) : interact
-    pointerMoveTolerance ( tol?: number ) : number | interact
+    stop ( event: any ) : InteractStatic
+    pointerMoveTolerance ( tol?: number ) : number | InteractStatic
     // TODO
     isSet ( any ) : any
     off ( any ) : any
@@ -294,6 +294,8 @@ declare module "interact.js/interact" {
     addDocument ( any ) : any
     removeDocument ( any ) : any
   }
-
-  export var interact : interact
 }
+
+declare var interact:interact.InteractStatic;
+export as namespace interact;
+export = interact;

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ declare namespace interact {
     maxPerElement?: number
     manualStart?: boolean
     snap?: SnapOptions
-    restrict?: ResizableOptions
+    restrict?: RestrictOption;
     inertia?: InertiaOptions
     autoScroll?: AutoScrollOptions
     axis?: 'x' | 'y'
@@ -101,7 +101,7 @@ declare namespace interact {
     maxPerElement?: number
     manualStart?: boolean
     snap?: SnapOptions
-    restrict?: ResizableOptions
+    restrict?: RestrictOption;
     inertia?: InertiaOptions
     autoScroll?: AutoScrollOptions
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "src/",
     "index.js",
     "LICENSE",
-    "interact.d.ts",
+    "index.d.ts",
     "interact-test.ts"
   ],
   "main": "dist/interact.js",


### PR DESCRIPTION
This fixes a series of issues with the typescript typings:

1. The previous code was set in a way that the typings were not automatically discoverable by the TypeScript compiler. There are multiple ways to solve the issue. The simplest one given the presence of `index.js` is just to rename the typings `index.d.ts`, which is what I did.

2. The `.d.ts` file contained a hardcoded module name. There's no reason for this. I've modified the file to remove the hardcoded name and at the same time took care to edit it so that it works both when interact.js is loaded as a module and when it is assumed to have been preloaded into the global space.

3. I fixed the way the ``restrict`` option was defined.