### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installation
     * Download the file interact.js (development version) into a new sub-directory: vendor/assets/javascripts/interact
     * Add ```//= require interact/interact``` in app/assets/javascripts/application.js (above ```//= require_tree .```)
     * Restart the Rails server
-* [jsDelivr CDN](http://www.jsdelivr.com/#!interact.js): `<script src="//cdn.jsdelivr.net/interact.js/1.2.8/interact.min.js"></script>`
+* [jsDelivr CDN](http://www.jsdelivr.com/#!interact.js): `<script src="//cdn.jsdelivr.net/npm/interactjs@1.2.9/dist/interact.min.js"></script>`
 * [cdnjs CDN](https://cdnjs.com/libraries/interact.js): `<script src="//cdnjs.cloudflare.com/ajax/libs/interact.js/1.2.8/interact.min.js"></script>`
 
 Documentation

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "interact-test.ts"
   ],
   "main": "index.js",
+  "jsdelivr": "dist/interact.min.js",
   "scripts": {
     "start": "node build --watch",
     "build": "node build --docs",


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.
I also changed the default file to `dist/interact.min.js`

You can find links for all files at https://www.jsdelivr.com/package/npm/interactjs.

Feel free to ping me if you have any questions regarding this change.