### PR TITLE
remove duplicate gesture event

### DIFF
--- a/src/actions/gesture.js
+++ b/src/actions/gesture.js
@@ -39,8 +39,6 @@ InteractEvent.signals.on('new', function ({ iEvent, interaction }) {
 
   iEvent.ds = iEvent.scale - interaction.gesture.scale;
 
-  interaction.target.fire(iEvent);
-
   interaction.gesture.prevAngle = iEvent.angle;
   interaction.gesture.prevDistance = iEvent.distance;
 


### PR DESCRIPTION
Gesture events shouldn't be fired twice once in gesture.js and once in base.js
Should fix bug  #695 for the 1.3 branch