### PR TITLE
Fix: Memory leak - Detached HTML elements 

### DIFF
--- a/packages/core/InteractableSet.ts
+++ b/packages/core/InteractableSet.ts
@@ -22,6 +22,10 @@ export default class InteractableSet {
         : target[this.scope.id]
 
       targetMappings.splice(targetMappings.findIndex((m) => m.context === context), 1)
+      if (interactable.target[scope.id]) {
+        interactable.target[scope.id].context = null
+        interactable.target[scope.id].interactable = null
+      }
     })
   }
 

--- a/packages/core/Interaction.d.ts
+++ b/packages/core/Interaction.d.ts
@@ -187,6 +187,7 @@ export declare class Interaction<T extends ActionName = any> {
     updatePointer(pointer: Interact.PointerType, event: Interact.PointerEventType, eventTarget: EventTarget, down?: boolean): number;
     removePointer(pointer: any, event: any): void;
     _updateLatestPointer(pointer: any, event: any, eventTarget: any): void;
+    destroy(): void;
     _createPreparedEvent(event: Interact.PointerEventType, phase: EventPhase, preEnd: boolean, type: string): InteractEvent<T, EventPhase>;
     _fireEvent(iEvent: any): void;
     _doPhase(signalArg: Partial<Interact.SignalArg>): boolean;

--- a/packages/core/Interaction.ts
+++ b/packages/core/Interaction.ts
@@ -454,6 +454,12 @@ export class Interaction<T extends ActionName = any> {
     this._latestPointer.eventTarget = eventTarget
   }
 
+  destroy () {
+    this._latestPointer.pointer = null
+    this._latestPointer.event = null
+    this._latestPointer.eventTarget = null
+  }
+
   _createPreparedEvent (event: Interact.PointerEventType, phase: EventPhase, preEnd: boolean, type: string) {
     const actionName = this.prepared.name
 

--- a/packages/core/scope.ts
+++ b/packages/core/scope.ts
@@ -92,7 +92,10 @@ export class Scope {
           if (interaction.interactable === this) {
             interaction.stop()
           }
+          interaction.destroy()
         }
+
+        scope.interactions.list = []
 
         scope.interactables.signals.fire('unset', { interactable: this })
       }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 PKG_DIR=$(dirname $(dirname $(readlink -f $0)))
+if [ -z "$PKG_DIR" ]
+then
+    PKG_DIR=$(dirname $(dirname $0))
+fi
 
 export PATH=$PKG_DIR/node_modules/.bin:$PWD/node_modules/.bin:$PATH
 export NODE_ENV=test


### PR DESCRIPTION
A proposed solution for the issue #713 

This solution adds a more complete cleaning routine to the `unset` method in order to remove all detached elements.

Also contains a little compatibility fix for the `test.sh` script that was not working on my MacOs (Mojave 10.14.4).

Cheers !