### PR TITLE
feat(modifiers/restrict): restrict intuitively to smaller restrictions

### DIFF
--- a/docs/restriction.md
+++ b/docs/restriction.md
@@ -4,6 +4,7 @@ Restrict
 interact.js has 3 restriction modifiers:
 
   - pointer coordinate-based `restrict`
+  - element rect-based restriction `restrictRect`
   - element size-based `restrictSize` (resize only)
   - and element edge-based `restrictEdges` (resize only)
 
@@ -35,27 +36,37 @@ The value can be:
  - a CSS selector string – if one of the parents of the target element matches
  this selector, it's rect will be used as the restriction area.
 
-`elementRect`
--------------
+`restrictRect()`
+----------------
 
 With the `restrict` variant, restricting is by default relative to the pointer
 coordinates so that the action coordinates, not the element's dimensions, will
-be kept within the restriction area. The `elementRect` option changes this so
+be kept within the restriction area. You can use the `restrictRect` variant so
 that the element's edges are considered while dragging.
 
 ```javascript
 interact(target).draggable({
     modifiers: [
-      interact.modifiers.restrict({
-        elementRect: { left: 0, right: 0, top: 1, bottom: 1 }
+      interact.modifiers.restrictRect({
+        restriction: 'parent'
       })
     ]
   })
 ```
 
-For the left and right properties, 0 means the left edge of the element and 1
-means the right edge. For top and bottom, 0 means the top edge of the element
-and 1 means the bottom.
+If the target element is larger than the restriction, then the element will be
+allowed to move around the restriction.
+
+### `elementRect`
+
+`restrictRect` is identical to `restrict`, but the `elementRect` option is set
+to a helpful default of `{ left: 0, right: 0, top: 1, bottom: 1 }`. The
+`elementRect` option specifies the area of the element to consider as its edges
+as scalar values from the top left edges to the bottom right.
+
+For the `left` and `right` properties, `0` means the left edge of the element
+and `1` means the right edge. For `top` and `bottom`, `0 means` the top edge of
+the element and 1 means the bottom.
 
 `{ top: 0.25, left: 0.25, bottom: 0.75, right: 0.75 }` would result in a quarter
 of the element being allowed to hang over the restriction edges.

--- a/packages/modifiers/index.ts
+++ b/packages/modifiers/index.ts
@@ -1,6 +1,7 @@
 import base from './base'
 import restrictEdgesModule from './restrict/edges'
 import restrictModule from './restrict/pointer'
+import restrictRectModule from './restrict/rect'
 import restrictSizeModule from './restrict/size'
 import snapEdgesModule from './snap/edges'
 import snapModule from './snap/pointer'
@@ -12,5 +13,6 @@ export const snap = makeModifier(snapModule, 'snap')
 export const snapSize = makeModifier(snapSizeModule, 'snapSize')
 export const snapEdges = makeModifier(snapEdgesModule, 'snapEdges')
 export const restrict = makeModifier(restrictModule, 'restrict')
+export const restrictRect = makeModifier(restrictRectModule, 'restrictRect')
 export const restrictEdges = makeModifier(restrictEdgesModule, 'restrictEdges')
 export const restrictSize = makeModifier(restrictSizeModule, 'restrictSize')

--- a/packages/modifiers/restrict/edges.ts
+++ b/packages/modifiers/restrict/edges.ts
@@ -52,8 +52,8 @@ function set ({ coords, interaction, state }: {
   }
 
   const page = extend({}, coords)
-  const inner = getRestrictionRect(options.inner, interaction, page) || {}
-  const outer = getRestrictionRect(options.outer, interaction, page) || {}
+  const inner = getRestrictionRect(options.inner, interaction, page) || {} as Interact.Rect
+  const outer = getRestrictionRect(options.outer, interaction, page) || {} as Interact.Rect
 
   fixRect(inner, noInner)
   fixRect(outer, noOuter)

--- a/packages/modifiers/restrict/pointer.spec.ts
+++ b/packages/modifiers/restrict/pointer.spec.ts
@@ -1,0 +1,55 @@
+import test from '@interactjs/_dev/test/test'
+import * as helpers from '@interactjs/core/tests/_helpers'
+import restrict from '../restrict/pointer'
+
+test('restrict larger than restriction', (t) => {
+  const edges = { left: 0, top: 0, right: 200, bottom: 200 }
+  const rect = { ...edges, width: 200, height: 200 }
+  const {
+    interaction,
+  } = helpers.testEnv({ rect })
+
+  const restriction = { left: 100, top: 50, right: 150, bottom: 150 }
+  const options = {
+    ...restrict.defaults,
+    restriction,
+    elementRect: { left: 0, top: 0, right: 1, bottom: 1 },
+  }
+  const state = { options, offset: null }
+  const arg = {
+    interaction,
+    state,
+    rect,
+    startOffset: rect,
+    coords: null,
+    pageCoords: { x: 0, y: 0 },
+  }
+
+  restrict.start(arg)
+
+  arg.coords = { x: 0, y: 0 }
+  restrict.set(arg)
+  t.deepEqual(
+    arg.coords,
+    { x: 0, y: 0 },
+    'allows top and left edge values to be lower than the restriction'
+  )
+
+  arg.coords = { x: restriction.left + 10, y: restriction.top + 10 }
+  restrict.set(arg)
+  t.deepEqual(
+    arg.coords,
+    { x: restriction.left - rect.left, y: restriction.top - rect.top },
+    'keeps the top left edge values lower than the restriction'
+  )
+
+  arg.coords = { x: restriction.right - rect.right - 10, y: restriction.bottom - rect.right - 10 }
+  restrict.set(arg)
+  t.deepEqual(
+    arg.coords,
+    { x: restriction.right - rect.right, y: restriction.bottom - rect.right },
+    'keeps the bottom right edge values higher than the restriction'
+  )
+
+  t.end()
+})

--- a/packages/modifiers/restrict/pointer.ts
+++ b/packages/modifiers/restrict/pointer.ts
@@ -2,7 +2,7 @@ import extend from '@interactjs/utils/extend'
 import * as is from '@interactjs/utils/is'
 import rectUtils from '@interactjs/utils/rect'
 
-function start ({ rect, startOffset, state }) {
+function start ({ rect, startOffset, state, interaction, pageCoords }) {
   const { options } = state
   const { elementRect } = options
   const offset: Interact.Rect = extend({
@@ -13,6 +13,19 @@ function start ({ rect, startOffset, state }) {
   }, options.offset || {})
 
   if (rect && elementRect) {
+    const restriction = getRestrictionRect(options.restriction, interaction, pageCoords)
+    const widthDiff = (restriction.right - restriction.left) - rect.width
+    const heightDiff = (restriction.bottom - restriction.top) - rect.height
+
+    if (widthDiff < 0) {
+      offset.left += widthDiff
+      offset.right += widthDiff
+    }
+    if (heightDiff < 0) {
+      offset.top += heightDiff
+      offset.bottom += heightDiff
+    }
+
     offset.left += startOffset.left - (rect.width  * elementRect.left)
     offset.top  += startOffset.top  - (rect.height * elementRect.top)
 
@@ -28,21 +41,12 @@ function set ({ coords, interaction, state }) {
 
   const restriction = getRestrictionRect(options.restriction, interaction, coords)
 
-  if (!restriction) { return state }
+  if (!restriction) { return }
 
-  const rect = restriction
+  const rect = rectUtils.xywhToTlbr(restriction)
 
-  // object is assumed to have
-  // x, y, width, height or
-  // left, top, right, bottom
-  if ('x' in restriction && 'y' in restriction) {
-    coords.x = Math.max(Math.min(rect.x + rect.width  - offset.right, coords.x), rect.x + offset.left)
-    coords.y = Math.max(Math.min(rect.y + rect.height - offset.bottom, coords.y), rect.y + offset.top)
-  }
-  else {
-    coords.x = Math.max(Math.min(rect.right  - offset.right, coords.x), rect.left + offset.left)
-    coords.y = Math.max(Math.min(rect.bottom - offset.bottom, coords.y), rect.top  + offset.top)
-  }
+  coords.x = Math.max(Math.min(rect.right  - offset.right, coords.x), rect.left + offset.left)
+  coords.y = Math.max(Math.min(rect.bottom - offset.bottom, coords.y), rect.top  + offset.top)
 }
 
 function getRestrictionRect (value, interaction, coords?: Interact.Point) {
@@ -53,16 +57,18 @@ function getRestrictionRect (value, interaction, coords?: Interact.Point) {
   }
 }
 
+const defaults: Interact.RestrictOptions = {
+  enabled: false,
+  restriction: null,
+  elementRect: null,
+  offset: null,
+}
+
 const restrict = {
   start,
   set,
   getRestrictionRect,
-  defaults: {
-    enabled: false,
-    restriction: null,
-    elementRect: null,
-    offset: null,
-  },
+  defaults,
 }
 
 export default restrict

--- a/packages/modifiers/restrict/rect.ts
+++ b/packages/modifiers/restrict/rect.ts
@@ -1,0 +1,17 @@
+import extend from '@interactjs/utils/extend'
+import restrictPointer from './pointer'
+
+const defaults = extend({
+  get elementRect () {
+    return { top: 0, left: 0, bottom: 1, right: 1 }
+  },
+  set elementRect (_) {},
+}, restrictPointer.defaults)
+
+const restrictRect = {
+  start: restrictPointer.start,
+  set: restrictPointer.set,
+  defaults,
+}
+
+export default restrictRect

--- a/packages/types/types.d.ts
+++ b/packages/types/types.d.ts
@@ -64,6 +64,10 @@ declare namespace Interact {
 
   export type FullRect = Required<Rect>
 
+  export type RectFunction<T extends any[] = []> = (...args: T) => Interact.Rect
+
+  export type RectResolvable<T extends any[] = []> = Rect | string | Element | RectFunction<T>
+
   export interface Dimensions {
     x: number
     y: number
@@ -100,7 +104,7 @@ declare namespace Interact {
   export type InertiaOptions = InertiaOption | boolean
 
   export interface AutoScrollOption {
-    container?: DOMElement
+    container?: Element
     margin?: number
     distance?: number
     interval?: number
@@ -108,15 +112,16 @@ declare namespace Interact {
   export type AutoScrollOptions = AutoScrollOption | boolean
 
   export type CSSSelector = string
-  export type DOMElement = any
 
-  export interface RestrictOption {
+  export interface RestrictOptions {
+    enabled?
     // where to drag over
-    restriction?: Rect | Dimensions | CSSSelector | DOMElement | 'self' | 'parent'
+    restriction?: Rect | Dimensions | CSSSelector | Element | 'self' | 'parent'
     // what part of self is allowed to drag over
     elementRect?: Rect
     // restrict just before the end drag
     endOnly?: boolean
+    offset?: Rect
   }
 
   export interface RestrictSizeOption {
@@ -125,11 +130,11 @@ declare namespace Interact {
   }
 
   export interface EdgeOptions {
-    top?: boolean | CSSSelector | DOMElement
-    left?: boolean | CSSSelector | DOMElement
-    bottom?: boolean | CSSSelector | DOMElement
-    right?: boolean | CSSSelector | DOMElement
-    [key: string]: boolean | CSSSelector | DOMElement
+    top?: boolean | CSSSelector | Element
+    left?: boolean | CSSSelector | Element
+    bottom?: boolean | CSSSelector | Element
+    right?: boolean | CSSSelector | Element
+    [key: string]: boolean | CSSSelector | Element
   }
 
   export interface ActionMethod<T> {
@@ -208,17 +213,17 @@ declare namespace Interact {
     pointerEvent: any,
     defaultAction: string,
     interactable: Interactable,
-    element: DOMElement,
+    element: Element,
     interaction: Interaction,
   ) => ActionProps
 
-  export type OriginFunction = (target: DOMElement)  => 'self' | 'parent' | Rect | Point | CSSSelector | DOMElement
+  export type OriginFunction = (target: Element)  => 'self' | 'parent' | Rect | Point | CSSSelector | Element
 
   export interface PointerEventsOptions {
     holdDuration?: number
     allowFrom?: string
     ignoreFrom?: string
-    origin?: 'self' | 'parent' | Rect | Point | CSSSelector | DOMElement | OriginFunction
+    origin?: 'self' | 'parent' | Rect | Point | CSSSelector | Element | OriginFunction
   }
 
   export type RectChecker = (element: Element)  => Rect
@@ -295,7 +300,7 @@ declare namespace Interact {
   export type OnEvent = OnEventName | OnEventName[]
 
   export interface InteractOptions {
-    context?: DOMElement
+    context?: Element
   }
 }
 

--- a/packages/utils/rect.ts
+++ b/packages/utils/rect.ts
@@ -10,20 +10,19 @@ export function getStringOptionResult (value, interactable, element) {
   return closest(element, value)
 }
 
-export function resolveRectLike (value, interactable?, element?, functionArgs?) {
+export function resolveRectLike<T extends any[] = []> (value: Interact.RectResolvable<T>, interactable?, element?, functionArgs?: T) {
   if (is.string(value)) {
     value = getStringOptionResult(value, interactable, element)
   }
-
-  if (is.func(value)) {
-    value = value.apply(null, functionArgs)
+  else if (is.func(value)) {
+    value = value(...functionArgs)
   }
 
   if (is.element(value)) {
     value = getElementRect(value)
   }
 
-  return value
+  return value as Interact.Rect
 }
 
 export function rectToXY (rect) {


### PR DESCRIPTION
Also add `interact.modifiers.restrictRect` with pre-set `elementRect` option.

```js
interact(target).draggable({
  modifiers: [interact.modifiers.restrictRect({
    restriction: 'parent',
    // elementRect defaults to `{ top: 0, left: 0, bottom: 1, right: 1 }`
  }]
})
```

Close #159