### PR TITLE
feat(auto-start): custom cursors with cursorChecker function

### DIFF
--- a/docs/draggable.md
+++ b/docs/draggable.md
@@ -73,3 +73,21 @@ action to start. Use `'x'` to require the user to start dragging horizontally or
 
 `lockAxis` causes the drag events to change only in the given axis. If a value
 of `'start'` is used, then the drag will be locked to the starting direction.
+
+`cursorChecker`
+---------------
+
+```javascript
+interact(target).draggable({
+  cursorChecker: (action, interatable, element) => {
+    switch (action.axis) {
+      case 'x': return 'ew-resize'
+      case 'y': return 'ns-resize'
+      case 'xy': return 'grab'
+    }
+  }
+})
+```
+
+You can tell interact.js which cursor to set on the target with a
+`cursorChecker` function.

--- a/docs/resizable.md
+++ b/docs/resizable.md
@@ -96,5 +96,23 @@ to dimensions less than `0x0`. The possible values are:
 
 [Demo on Codepen][resize-codepen]
 
+`cursorChecker`
+---------------
+
+```javascript
+interact(target).resizable({
+  edges: { bottom: true, right: true },
+  cursorChecker: (action, interatable, element) => {
+    if (action.edges.bottom && action.edges.right) {
+      return 'sw-resize'
+    }
+    // etc.
+  }
+})
+```
+
+You can tell interact.js which cursor to set on the target with a
+`cursorChecker` function.
+
 [interaction-start]: http://interactjs.io/api/#Interaction.start
 [resize-codepen]: http://codepen.io/taye/pen/LEpmOL

--- a/packages/auto-start/autoStart.spec.ts
+++ b/packages/auto-start/autoStart.spec.ts
@@ -1,20 +1,21 @@
 import test from '@interactjs/_dev/test/test'
 import drag from '@interactjs/actions/drag'
 import * as helpers from '@interactjs/core/tests/_helpers'
-import * as utils from '@interactjs/utils'
 import autoStart from './base'
 
 test('autoStart', (t) => {
-  const scope: Interact.Scope = helpers.mockScope()
-
-  scope.usePlugin(autoStart)
-  scope.usePlugin(drag)
-
-  const interaction = scope.interactions.new({})
-  const element = scope.document.body
-  const interactable = scope.interactables.new(element).draggable(true)
-  const event = utils.pointer.coordsToEvent(utils.pointer.newCoords())
   const rect = { top: 100, left: 200, bottom: 300, right: 400 }
+  const {
+    interaction,
+    interactable,
+    event,
+    target: element,
+  } = helpers.testEnv({
+    plugins: [autoStart, drag],
+    rect,
+  })
+
+  interactable.draggable(true)
   interactable.rectChecker(() => ({ ...rect }))
 
   interaction.pointerDown(event, event, element)
@@ -30,6 +31,29 @@ test('autoStart', (t) => {
     rect as any,
     'set interaction.rect'
   )
+
+  t.equal(element.style.cursor, 'move', 'sets drag cursor')
+
+  let checkerArgs
+
+  interactable.draggable({
+    cursorChecker (...args) {
+      checkerArgs = args
+
+      return 'custom-cursor'
+    },
+  })
+
+  interaction.pointerDown(event, event, element)
+
+  t.deepEqual(
+    checkerArgs,
+    [{ name: 'drag', axis: 'xy' }, interactable, element],
+    'calls cursorChecker with expected args'
+  )
+
+  interaction.pointerDown(event, event, element)
+  t.equal(element.style.cursor, 'custom-cursor', 'uses cursorChecker value')
 
   t.end()
 })

--- a/packages/auto-start/autoStart.spec.ts
+++ b/packages/auto-start/autoStart.spec.ts
@@ -9,6 +9,7 @@ test('autoStart', (t) => {
     interaction,
     interactable,
     event,
+    coords,
     target: element,
   } = helpers.testEnv({
     plugins: [autoStart, drag],
@@ -16,7 +17,8 @@ test('autoStart', (t) => {
   })
 
   interactable.draggable(true)
-  interactable.rectChecker(() => ({ ...rect }))
+  interaction.pointerType = coords.pointerType = 'mouse'
+  coords.buttons = 1
 
   interaction.pointerDown(event, event, element)
 

--- a/packages/auto-start/base.ts
+++ b/packages/auto-start/base.ts
@@ -223,9 +223,21 @@ function prepare (interaction: Interact.Interaction, { action, interactable, ele
     ? interactable.getRect(element)
     : null
 
-  if (interactable && interactable.options.styleCursor) {
-    const cursor = action ? scope.actions[action.name].getCursor(action) : ''
-    setCursor(interaction.element as HTMLElement, cursor, scope)
+  if (interaction.pointerType === 'mouse' && interactable && interactable.options.styleCursor) {
+    let cursor = ''
+
+    if (action) {
+      const { cursorChecker } = interactable.options[action.name]
+
+      if (utils.is.func(cursorChecker)) {
+        cursor = cursorChecker(action, interactable, element)
+      }
+      else {
+        cursor = scope.actions[action.name].getCursor(action)
+      }
+    }
+
+    setCursor(interaction.element as HTMLElement, cursor || '', scope)
   }
 
   scope.autoStart.signals.fire('prepared', { interaction })

--- a/packages/types/types.d.ts
+++ b/packages/types/types.d.ts
@@ -132,6 +132,9 @@ declare namespace Interact {
     [key: string]: boolean | CSSSelector | DOMElement
   }
 
+  export type CursorChecker<T extends ActionName = any> =
+    (action: ActionProps, interactable: Interactable, element: Element) => string
+
   export interface ActionMethod<T> {
     (this: Interact.Interactable): T
     // eslint-disable-next-line no-undef
@@ -149,6 +152,7 @@ declare namespace Interact {
   export interface DraggableOptions extends Options {
     startAxis?: 'x' | 'y' | 'xy'
     lockAxis?: 'x' | 'y' | 'xy' | 'start'
+    cursorChecker?: Interact.CursorChecker
     oninertiastart?: ListenersArg
     onstart?: Interact.ListenersArg
     onmove?: Interact.ListenersArg
@@ -192,6 +196,7 @@ declare namespace Interact {
     invert?: 'none' | 'negate' | 'reposition'
     margin?: number,
     squareResize?: boolean
+    cursorChecker?: Interact.CursorChecker
     oninertiastart?: ListenersArg
     onstart?: Interact.ListenersArg
     onmove?: Interact.ListenersArg

--- a/packages/utils/pointerUtils.ts
+++ b/packages/utils/pointerUtils.ts
@@ -248,6 +248,7 @@ const pointerUtils = {
       get target () { return this.coords.target },
       get type () { return this.coords.type },
       get pointerType () { return this.coords.pointerType },
+      get buttons () { return this.coords.buttons },
     }
 
     return event as typeof event & Interact.PointerType & Interact.PointerEventType
@@ -264,4 +265,5 @@ export interface MockCoords {
   target?: any
   type?: string
   pointerType?: string
+  buttons?: number
 }


### PR DESCRIPTION
```js
interact(target).draggable({
  cursorChecker: (action, interactable, element) => {
    switch (action.axis) {
      case 'x': return 'ew-resize'
      case 'y': return 'ns-resize'
      case 'xy': return 'grab'
    }
  }
})
```

Close #698
