### PR TITLE
Fix the problem that the draggable function does not work properly in Firefox extensions

### DIFF
--- a/@interactjs/utils/raf.ts
+++ b/@interactjs/utils/raf.ts
@@ -4,14 +4,14 @@ let cancel
 
 function init (window) {
   request = window.requestAnimationFrame
-  cancel = window.cancelAnimationFrame
+  let cancelFn = window.cancelAnimationFrame
 
   if (!request) {
     const vendors = ['ms', 'moz', 'webkit', 'o']
 
     for (const vendor of vendors) {
       request = window[`${vendor}RequestAnimationFrame`]
-      cancel = window[`${vendor}CancelAnimationFrame`] || window[`${vendor}CancelRequestAnimationFrame`]
+      cancelFn = window[`${vendor}CancelAnimationFrame`] || window[`${vendor}CancelRequestAnimationFrame`]
     }
   }
 
@@ -27,8 +27,10 @@ function init (window) {
       return token
     }
 
-    cancel = token => clearTimeout(token)
+    cancelFn = token => clearTimeout(token)
   }
+
+  cancel = token => cancelFn.call(window, token)
 }
 
 export default {


### PR DESCRIPTION
I used interact.js in my extension, but in Firefox, the draggable function is not working, because in Firefox extension, `cancelAnimationFrame` must be called in `window` context, otherwise it will report an error: `TypeError: 'cancelAnimationFrame' called on an object that does not implement interface Window.`

Steps to reproduce:

1. Clone https://github.com/lmk123/firefox-addon-interactjs-bug
2. In Firefox: Open the `about:debugging` page, click "This Firefox" (in newer versions of Firefox), click "Load Temporary Add-on", then select manifest.json file in the extension's directory.
3. Open https://www.google.com, a "drag me" text will appear in the upper left corner
4. Open dev tools, switch to the "Debugger" tab, and check the "Pause on exceptions" option on the right
5. Now, drag the "drag me" text

You will see this error in Debugger:

![image](https://user-images.githubusercontent.com/5035625/79777549-fd23ad80-8369-11ea-8b57-2fb02ae4a3f4.png)

You can edit manifest.json, replace `interact.js` to `interact-fixed.js`, reload the extension and the 
google web page, now everything work fine.
