### PR TITLE
fix(auto-scroll): add 'string' type to union of container types for AutoScrollOption

### DIFF
--- a/packages/@interactjs/auto-scroll/plugin.ts
+++ b/packages/@interactjs/auto-scroll/plugin.ts
@@ -27,7 +27,7 @@ declare module '@interactjs/core/options' {
 }
 
 export interface AutoScrollOptions {
-  container?: Window | HTMLElement
+  container?: Window | HTMLElement | string;
   margin?: number
   distance?: number
   interval?: number


### PR DESCRIPTION
autoScroll can already use css selectors to find appropriate container element, but TypeScript doesn't know about it and throws a compilation error. This fixes that.