### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/@interactjs/actions/package.json
+++ b/packages/@interactjs/actions/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/actions"
+  },
   "peerDependencies": {
     "@interactjs/core": "1.10.11",
     "@interactjs/utils": "1.10.11"

--- a/packages/@interactjs/auto-scroll/package.json
+++ b/packages/@interactjs/auto-scroll/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/auto-scroll"
+  },
   "peerDependencies": {
     "@interactjs/utils": "1.10.11"
   },

--- a/packages/@interactjs/auto-start/package.json
+++ b/packages/@interactjs/auto-start/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/auto-start"
+  },
   "peerDependencies": {
     "@interactjs/core": "1.10.11",
     "@interactjs/utils": "1.10.11"

--- a/packages/@interactjs/core/package.json
+++ b/packages/@interactjs/core/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/core"
+  },
   "peerDependencies": {
     "@interactjs/utils": "1.10.11"
   },

--- a/packages/@interactjs/dev-tools/package.json
+++ b/packages/@interactjs/dev-tools/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/dev-tools"
+  },
   "peerDependencies": {
     "@interactjs/modifiers": "1.10.11",
     "@interactjs/utils": "1.10.11"

--- a/packages/@interactjs/inertia/package.json
+++ b/packages/@interactjs/inertia/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/inertia"
+  },
   "dependencies": {
     "@interactjs/offset": "1.10.11"
   },

--- a/packages/@interactjs/interact/package.json
+++ b/packages/@interactjs/interact/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/interact"
+  },
   "dependencies": {
     "@interactjs/core": "1.10.11",
     "@interactjs/types": "1.10.11",

--- a/packages/@interactjs/modifiers/package.json
+++ b/packages/@interactjs/modifiers/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/modifiers"
+  },
   "dependencies": {
     "@interactjs/snappers": "1.10.11"
   },

--- a/packages/@interactjs/offset/package.json
+++ b/packages/@interactjs/offset/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/offset"
+  },
   "peerDependencies": {
     "@interactjs/core": "1.10.11",
     "@interactjs/utils": "1.10.11"

--- a/packages/@interactjs/pointer-events/package.json
+++ b/packages/@interactjs/pointer-events/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/pointer-events"
+  },
   "peerDependencies": {
     "@interactjs/core": "1.10.11",
     "@interactjs/utils": "1.10.11"

--- a/packages/@interactjs/reflow/package.json
+++ b/packages/@interactjs/reflow/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/reflow"
+  },
   "peerDependencies": {
     "@interactjs/core": "1.10.11",
     "@interactjs/utils": "1.10.11"

--- a/packages/@interactjs/snappers/package.json
+++ b/packages/@interactjs/snappers/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/snappers"
+  },
   "peerDependencies": {
     "@interactjs/utils": "1.10.11"
   },

--- a/packages/@interactjs/types/package.json
+++ b/packages/@interactjs/types/package.json
@@ -3,6 +3,11 @@
   "version": "1.10.11",
   "main": "index",
   "module": "index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/types"
+  },
   "typings": "typings.d.ts",
   "devDependencies": {
     "@interactjs/actions": "1.10.11",

--- a/packages/@interactjs/utils/package.json
+++ b/packages/@interactjs/utils/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@interactjs/utils",
   "version": "1.10.11",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/taye/interact.js.git",
+    "directory": "packages/@interactjs/utils"
+  },
   "peerDependencies": {
     "@interactjs/feedback": "1.10.11",
     "@interactjs/symbol-tree": "1.10.11"


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@rancyr](https://github.com/v-rr), [@Jaydon Peng](https://github.com/v-jiepeng), [@Zhongpeng Zhou](https://github.com/v-zhzhou) and [@Jingying Gu](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @interactjs/utils
* @interactjs/types
* @interactjs/snappers
* @interactjs/reflow
* @interactjs/pointer-events
* @interactjs/offset
* @interactjs/modifiers
* @interactjs/interact
* @interactjs/inertia
* @interactjs/dev-tools
* @interactjs/core
* @interactjs/auto-start
* @interactjs/auto-scroll
* @interactjs/actions

Make sure to include tests in your pull request.
