### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/@interactjs/core/isNonNativeEvent.ts
+++ b/packages/@interactjs/core/isNonNativeEvent.ts
@@ -6,7 +6,7 @@ export default function isNonNativeEvent (type: string, actions: Actions) {
   }
 
   for (const name in actions.map) {
-    if (type.indexOf(name) === 0 && type.substr(name.length) in actions.phases) {
+    if (type.indexOf(name) === 0 && type.slice(name.length) in actions.phases) {
       return true
     }
   }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.