### PR TITLE
Update babel.config.js

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,7 @@ module.exports = {
     [require.resolve('@babel/preset-env'), { exclude: ['transform-regenerator'] }],
     [
       require.resolve('@babel/preset-typescript'),
-      { isTsx: false, onlyRemoveTypeImports: true, allExtensions: true, allowDeclareFields: true },
+      { isTSX: false, onlyRemoveTypeImports: true, allExtensions: true, allowDeclareFields: true },
     ],
   ].filter(Boolean),
 


### PR DESCRIPTION
Babel maintainer here. The `isTsx` is an invalid option ([docs](https://babel.dev/docs/babel-preset-typescript#istsx) here), it should have been `isTSX`.