### PR TITLE
fix: click event below iOS 13 do not take effect

### DIFF
--- a/packages/@interactjs/core/interactablePreventDefault.ts
+++ b/packages/@interactjs/core/interactablePreventDefault.ts
@@ -55,7 +55,7 @@ function checkAndPreventDefault (interactable: Interactable, scope: Scope, event
   }
 
   // don't preventDefault of pointerdown events
-  if (/^(mouse|pointer|touch)*(down|start)/i.test(event.type)) {
+  if (/^(mouse|pointer|touch)*(down|start|end)/i.test(event.type)) {
     return
   }
 


### PR DESCRIPTION
fix: #859, #812

IOS devices below version 13 don't support pointer events. When a user clicks on a div, it will trigger a touchend event. However, the touchend event in the code is not properly filtered, and it will become ineffective due to the call to e.preventDefault.

normal:
![image](https://github.com/taye/interact.js/assets/49024935/7fa87112-b512-4f8a-801f-cecfdfdf2ecc)


iOS 11、12:
![image](https://github.com/taye/interact.js/assets/49024935/648372ee-2685-4570-a32e-0da71a84656c)


Pointer Compatibility:
![image](https://github.com/taye/interact.js/assets/49024935/5ab7937f-164e-40f0-9a31-3adc7b462907)

