### PR TITLE
typings.d.ts: write in ESM format

### DIFF
--- a/scripts/execTypes.js
+++ b/scripts/execTypes.js
@@ -14,10 +14,9 @@ module.exports = {
     shell.exec(`npx tsc -p types.tsconfig.json --rootDir packages --outFile ${outFile}`)
 
     const namespaceDeclaration = `
-import * as Interact from '@interactjs/types/index'
-
-export as namespace Interact
-export = Interact
+declare module '@interactjs/types' {
+  export * from '@interactjs/types/index';
+}
 `.trimStart()
 
     await fs.promises.writeFile(path.join(outDir, 'typings.d.ts'), namespaceDeclaration)


### PR DESCRIPTION
Commit 99aa76a22 indicates that
ESM is used, so write typings.d.ts
in that format too.

Fixes #1059