### PR TITLE
CI: enable tests to run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,6 @@ jobs:
       - name: 🔍 lint
         run: npx _lint
       - name: 🧪 tests
-        run: npm test
+        run: |
+          export PATH=`pwd`/node_modules/puppeteer/.local-chromium/linux-901912/chrome-linux:$PATH
+          npm test


### PR DESCRIPTION
Tests can't find the browser, so add it to `PATH`.