### PR TITLE
allowFrom and ignoreFrom with callback functions

### DIFF
--- a/examples/allowFrom-callback/index.html
+++ b/examples/allowFrom-callback/index.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>InteractJS - allowFrom Callback Example</title>
+    <style>
+        .draggable {
+            width: 250px;
+            height: 200px;
+            background: #e3f2fd;
+            border: 2px solid #1976d2;
+            margin: 20px;
+            padding: 10px;
+            border-radius: 8px;
+            position: relative;
+        }
+
+        .drag-handle {
+            background: #1976d2;
+            color: white;
+            padding: 8px;
+            margin-bottom: 10px;
+            cursor: move;
+            border-radius: 4px;
+            font-weight: bold;
+        }
+
+        .drag-handle:hover {
+            background: #1565c0;
+        }
+
+        .content-area {
+            background: white;
+            padding: 10px;
+            border-radius: 4px;
+            margin: 5px 0;
+            min-height: 60px;
+        }
+
+        .admin-only {
+            background: #ffeb3b;
+            padding: 5px;
+            margin: 5px 0;
+            border-radius: 3px;
+            border: 1px dashed #f57c00;
+        }
+
+        .editor-area {
+            background: #f3e5f5;
+            padding: 5px;
+            margin: 5px 0;
+            border-radius: 3px;
+            border: 1px dashed #7b1fa2;
+        }
+
+        .no-drag-zone {
+            background: #ffcdd2;
+            padding: 5px;
+            margin: 5px 0;
+            border-radius: 3px;
+            cursor: not-allowed;
+        }
+
+        input, textarea, select {
+            width: 100%;
+            margin: 5px 0;
+            padding: 5px;
+            border: 1px solid #ccc;
+            border-radius: 3px;
+        }
+
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background: #fafafa;
+        }
+
+        h1 {
+            color: #333;
+            text-align: center;
+        }
+
+        .info {
+            background: #e8f5e8;
+            padding: 15px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            border: 1px solid #4caf50;
+        }
+
+        .role-selector {
+            text-align: center;
+            margin: 20px 0;
+            padding: 10px;
+            background: white;
+            border-radius: 8px;
+            border: 1px solid #ddd;
+        }
+
+        .role-btn {
+            margin: 0 5px;
+            padding: 8px 16px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-weight: bold;
+        }
+
+        .role-btn.admin { background: #4caf50; color: white; }
+        .role-btn.editor { background: #ff9800; color: white; }
+        .role-btn.viewer { background: #9e9e9e; color: white; }
+        .role-btn.active { box-shadow: 0 0 0 2px #333; }
+
+        .demo-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 20px;
+        }
+    </style>
+</head>
+<body>
+    <h1>InteractJS - allowFrom with Callback Function</h1>
+    
+    <div class="info">
+        <p><strong>Demonstration of the `allowFrom` option with callback:</strong></p>
+        <ul>
+            <li>Only certain areas allow drag initiation</li>
+            <li>Logic is fully customizable via a callback function</li>
+            <li>Change your role below to see different behaviors</li>
+        </ul>
+    </div>
+
+    <div class="role-selector">
+        <span><strong>Your role: </strong></span>
+        <button class="role-btn admin active" data-role="admin">👑 Admin</button>
+        <button class="role-btn editor" data-role="editor">✏️ Editor</button>
+        <button class="role-btn viewer" data-role="viewer">👁️ Viewer</button>
+    </div>
+
+    <div class="demo-container">
+        <div class="draggable" id="handle-only">
+            <div class="drag-handle">✋ Handle Only</div>
+            <div class="content-area">
+                <p>This container can only be moved by grabbing the blue handle above.</p>
+                <input type="text" placeholder="Non-draggable area">
+                <p>Try clicking here... it won't work!</p>
+            </div>
+        </div>
+
+        <div class="draggable" id="role-based">
+            <div class="drag-handle">🔐 Role-based Access</div>
+            <div class="admin-only" data-role-required="admin">
+                👑 Admin Only Zone - Drag allowed if role = Admin
+            </div>
+            <div class="editor-area" data-role-required="editor">
+                ✏️ Editor+ Zone - Drag allowed if role = Admin or Editor
+            </div>
+            <div class="no-drag-zone">
+                ⛔ Forbidden Zone - No dragging possible
+            </div>
+        </div>
+
+        <div class="draggable" id="advanced-logic">
+            <div class="drag-handle">🧠 Advanced Logic</div>
+            <div class="content-area">
+                <div data-draggable="conditional">📝 Conditional zone (role-based)</div>
+                <input type="text" placeholder="Input never draggable">
+                <div class="admin-only" data-special="admin-feature">
+                    🔧 Admin special feature
+                </div>
+                <select>
+                    <option>Select never draggable</option>
+                </select>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
+    <script>
+        let currentRole = 'admin';
+
+        // Role button management
+        document.querySelectorAll('.role-btn').forEach(btn => {
+            btn.addEventListener('click', () => {
+                document.querySelectorAll('.role-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
+                currentRole = btn.dataset.role;
+                console.log('Role changed:', currentRole);
+            });
+        });
+
+        // Configuration for "handle-only" draggable
+        interact('#handle-only').draggable({
+            allowFrom: function(targetNode, eventTarget) {
+                // Only allow dragging from the handle
+                if (eventTarget.classList.contains('drag-handle')) {
+                    console.log('✅ Drag allowed: handle detected');
+                    return true;
+                }
+                console.log('❌ Drag denied: not on handle');
+                return false;
+            },
+            
+            listeners: {
+                start: function(event) {
+                    event.target.style.opacity = 0.8;
+                    event.target.style.transform += ' scale(1.05)';
+                },
+                move: dragMoveListener,
+                end: function(event) {
+                    event.target.style.opacity = '';
+                    event.target.style.transform = event.target.style.transform.replace(' scale(1.05)', '');
+                }
+            }
+        });
+
+        // Configuration for "role-based" draggable
+        interact('#role-based').draggable({
+            allowFrom: function(targetNode, eventTarget) {
+                // Always allow from handle
+                if (eventTarget.classList.contains('drag-handle')) {
+                    console.log('✅ Drag allowed: handle');
+                    return true;
+                }
+
+                // Check role requirements
+                const roleRequired = eventTarget.getAttribute('data-role-required');
+                if (roleRequired) {
+                    const allowed = checkRoleAccess(currentRole, roleRequired);
+                    console.log(`${allowed ? '✅' : '❌'} Role ${currentRole} for ${roleRequired} zone: ${allowed ? 'allowed' : 'denied'}`);
+                    return allowed;
+                }
+
+                // Explicitly forbid certain zones
+                if (eventTarget.classList.contains('no-drag-zone')) {
+                    console.log('❌ Explicitly forbidden zone');
+                    return false;
+                }
+
+                console.log('❌ Zone not allowed by default');
+                return false;
+            },
+            
+            listeners: {
+                start: function(event) {
+                    event.target.style.opacity = 0.8;
+                    event.target.style.boxShadow = '0 8px 16px rgba(0,0,0,0.3)';
+                },
+                move: dragMoveListener,
+                end: function(event) {
+                    event.target.style.opacity = '';
+                    event.target.style.boxShadow = '';
+                }
+            }
+        });
+
+        // Configuration for "advanced-logic" draggable
+        interact('#advanced-logic').draggable({
+            allowFrom: function(targetNode, eventTarget) {
+                // Handle always OK
+                if (eventTarget.classList.contains('drag-handle')) {
+                    return true;
+                }
+
+                // Never allow inputs/selects
+                if (['INPUT', 'SELECT', 'TEXTAREA'].includes(eventTarget.tagName)) {
+                    console.log('❌ Form element forbidden');
+                    return false;
+                }
+
+                // Conditional logic
+                if (eventTarget.hasAttribute('data-draggable')) {
+                    const condition = eventTarget.getAttribute('data-draggable');
+                    if (condition === 'conditional') {
+                        const allowed = currentRole === 'admin' || currentRole === 'editor';
+                        console.log(`${allowed ? '✅' : '❌'} Conditional draggable for ${currentRole}`);
+                        return allowed;
+                    }
+                }
+
+                // Admin special features
+                if (eventTarget.hasAttribute('data-special')) {
+                    const allowed = currentRole === 'admin';
+                    console.log(`${allowed ? '✅' : '❌'} Special feature for ${currentRole}`);
+                    return allowed;
+                }
+
+                return false;
+            },
+            
+            listeners: {
+                start: function(event) {
+                    event.target.style.opacity = 0.8;
+                    event.target.style.border = '2px solid #4caf50';
+                },
+                move: dragMoveListener,
+                end: function(event) {
+                    event.target.style.opacity = '';
+                    event.target.style.border = '2px solid #1976d2';
+                }
+            }
+        });
+
+        function checkRoleAccess(userRole, requiredRole) {
+            const roles = { viewer: 0, editor: 1, admin: 2 };
+            return roles[userRole] >= roles[requiredRole];
+        }
+
+        function dragMoveListener(event) {
+            var target = event.target;
+            var x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
+            var y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+
+            target.style.transform = 'translate(' + x + 'px, ' + y + 'px)';
+            target.setAttribute('data-x', x);
+            target.setAttribute('data-y', y);
+        }
+    </script>
+</body>
+</html>

--- a/examples/combined-callbacks/index.html
+++ b/examples/combined-callbacks/index.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>InteractJS - allowFrom & ignoreFrom Callbacks Combined</title>
+    <style>
+        .draggable {
+            width: 300px;
+            height: 250px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            border: 2px solid #333;
+            margin: 20px;
+            padding: 15px;
+            border-radius: 12px;
+            position: relative;
+            color: white;
+        }
+
+        .drag-handle {
+            background: rgba(255,255,255,0.9);
+            color: #333;
+            padding: 10px;
+            margin-bottom: 15px;
+            cursor: move;
+            border-radius: 6px;
+            font-weight: bold;
+            text-align: center;
+        }
+
+        .allowed-zone {
+            background: rgba(76, 175, 80, 0.3);
+            border: 2px dashed #4caf50;
+            padding: 10px;
+            margin: 5px 0;
+            border-radius: 6px;
+            cursor: move;
+        }
+
+        .ignored-zone {
+            background: rgba(244, 67, 54, 0.3);
+            border: 2px dashed #f44336;
+            padding: 10px;
+            margin: 5px 0;
+            border-radius: 6px;
+            cursor: not-allowed;
+        }
+
+        .neutral-zone {
+            background: rgba(255, 152, 0, 0.3);
+            border: 2px dashed #ff9800;
+            padding: 10px;
+            margin: 5px 0;
+            border-radius: 6px;
+        }
+
+        .priority-zone {
+            background: rgba(156, 39, 176, 0.3);
+            border: 2px dashed #9c27b0;
+            padding: 10px;
+            margin: 5px 0;
+            border-radius: 6px;
+            position: relative;
+        }
+
+        .priority-zone .allowed-nested {
+            background: rgba(76, 175, 80, 0.5);
+            border: 1px solid #4caf50;
+            padding: 5px;
+            margin: 5px 0;
+            border-radius: 3px;
+            cursor: move;
+        }
+
+        .priority-zone .ignored-nested {
+            background: rgba(244, 67, 54, 0.5);
+            border: 1px solid #f44336;
+            padding: 5px;
+            margin: 5px 0;
+            border-radius: 3px;
+            cursor: not-allowed;
+        }
+
+        input, textarea {
+            width: 95%;
+            margin: 5px 0;
+            padding: 5px;
+            border: 1px solid #ddd;
+            border-radius: 3px;
+        }
+
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+            background: #f0f0f0;
+        }
+
+        h1 {
+            color: #333;
+            text-align: center;
+        }
+
+        .info {
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            margin-bottom: 20px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+
+        .legend {
+            display: flex;
+            justify-content: space-around;
+            flex-wrap: wrap;
+            background: white;
+            padding: 15px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            margin: 5px;
+        }
+
+        .legend-color {
+            width: 20px;
+            height: 20px;
+            border-radius: 4px;
+            margin-right: 8px;
+            border: 2px solid #333;
+        }
+
+        .demo-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 20px;
+        }
+
+        .log-container {
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            width: 300px;
+            height: 200px;
+            background: rgba(0,0,0,0.9);
+            color: #00ff00;
+            padding: 10px;
+            border-radius: 8px;
+            font-family: monospace;
+            font-size: 12px;
+            overflow-y: auto;
+            z-index: 1000;
+        }
+
+        .log-container h4 {
+            color: white;
+            margin: 0 0 10px 0;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <h1>InteractJS - allowFrom & ignoreFrom with Callbacks</h1>
+    
+    <div class="info">
+        <p><strong>Advanced demonstration combining allowFrom and ignoreFrom:</strong></p>
+        <p>This example shows how to use both options together with callback functions to create sophisticated access control logic.</p>
+        <p><strong>Logic:</strong> allowFrom determines allowed zones, then ignoreFrom can override and forbid specific zones.</p>
+    </div>
+
+    <div class="legend">
+        <div class="legend-item">
+            <div class="legend-color" style="background: rgba(76, 175, 80, 0.3); border-color: #4caf50;"></div>
+            <span>Allowed zone (allowFrom)</span>
+        </div>
+        <div class="legend-item">
+            <div class="legend-color" style="background: rgba(244, 67, 54, 0.3); border-color: #f44336;"></div>
+            <span>Ignored zone (ignoreFrom)</span>
+        </div>
+        <div class="legend-item">
+            <div class="legend-color" style="background: rgba(255, 152, 0, 0.3); border-color: #ff9800;"></div>
+            <span>Neutral zone</span>
+        </div>
+        <div class="legend-item">
+            <div class="legend-color" style="background: rgba(156, 39, 176, 0.3); border-color: #9c27b0;"></div>
+            <span>Priority zone</span>
+        </div>
+    </div>
+
+    <div class="demo-container">
+        <div class="draggable" id="complex-draggable">
+            <div class="drag-handle">🎯 Complex Access Control</div>
+            
+            <div class="allowed-zone" data-allow="basic">
+                ✅ Basic allowed zone
+                <input type="text" placeholder="Input in allowed zone (ignored)">
+            </div>
+
+            <div class="ignored-zone" data-ignore="always">
+                ❌ Always ignored zone
+                <div class="allowed-zone" data-allow="nested">
+                    Even if nested in allowed, it's ignored
+                </div>
+            </div>
+
+            <div class="neutral-zone">
+                ⚪ Neutral zone (not allowed by default)
+            </div>
+
+            <div class="priority-zone" data-context="priority">
+                🔥 Priority management zone
+                <div class="allowed-nested" data-priority="high">
+                    ✨ High priority (allowed)
+                </div>
+                <div class="ignored-nested" data-maintenance="true">
+                    🔧 Under maintenance (ignored)
+                </div>
+            </div>
+        </div>
+
+        <div class="draggable" id="role-permissions">
+            <div class="drag-handle">👥 Role-based Permissions</div>
+            
+            <div class="allowed-zone" data-min-role="user">
+                👤 User zone (all roles)
+            </div>
+
+            <div class="priority-zone" data-min-role="admin">
+                👑 Admin only zone
+                <div class="ignored-zone" data-ignore="sensitive">
+                    🔒 Sensitive data (always ignored)
+                </div>
+                <div class="allowed-nested" data-allow="admin-tools">
+                    🛠️ Admin tools
+                </div>
+            </div>
+
+            <textarea placeholder="TextArea always ignored"></textarea>
+        </div>
+    </div>
+
+    <div class="log-container" id="logContainer">
+        <h4>📊 Decision Log</h4>
+        <div id="logContent"></div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
+    <script>
+        let currentRole = 'admin'; // Simulate user role
+        
+        function log(message, type = 'info') {
+            const logContent = document.getElementById('logContent');
+            const timestamp = new Date().toLocaleTimeString();
+            const colors = {
+                allow: '#4caf50',
+                ignore: '#f44336',
+                info: '#00ff00'
+            };
+            
+            logContent.innerHTML += `<div style="color: ${colors[type] || colors.info}">[${timestamp}] ${message}</div>`;
+            logContent.scrollTop = logContent.scrollHeight;
+            
+            // Keep only the last 20 messages
+            const messages = logContent.children;
+            while (messages.length > 20) {
+                logContent.removeChild(messages[0]);
+            }
+        }
+
+        // Configuration for complex draggable
+        interact('#complex-draggable').draggable({
+            allowFrom: function(targetNode, eventTarget) {
+                log(`🔍 allowFrom check: ${eventTarget.className || eventTarget.tagName}`);
+                
+                // Always allow handle
+                if (eventTarget.classList.contains('drag-handle')) {
+                    log('✅ Handle detected - ALLOWED', 'allow');
+                    return true;
+                }
+
+                // Allow explicitly marked zones
+                if (eventTarget.hasAttribute('data-allow')) {
+                    log(`✅ Allowed zone: ${eventTarget.getAttribute('data-allow')}`, 'allow');
+                    return true;
+                }
+
+                // Allow based on priority
+                if (eventTarget.hasAttribute('data-priority')) {
+                    const priority = eventTarget.getAttribute('data-priority');
+                    const allowed = priority === 'high';
+                    log(`${allowed ? '✅' : '❌'} Priority ${priority}: ${allowed ? 'ALLOWED' : 'DENIED'}`, allowed ? 'allow' : 'ignore');
+                    return allowed;
+                }
+
+                // Check parents
+                let parent = eventTarget.parentElement;
+                while (parent && parent !== targetNode) {
+                    if (parent.hasAttribute('data-allow')) {
+                        log(`✅ Allowed parent found: ${parent.getAttribute('data-allow')}`, 'allow');
+                        return true;
+                    }
+                    parent = parent.parentElement;
+                }
+
+                log('❌ No authorization found - DENIED', 'ignore');
+                return false;
+            },
+
+            ignoreFrom: function(targetNode, eventTarget) {
+                log(`🔍 ignoreFrom check: ${eventTarget.className || eventTarget.tagName}`);
+                
+                // Always ignore inputs
+                if (['INPUT', 'TEXTAREA', 'SELECT'].includes(eventTarget.tagName)) {
+                    log('❌ Form element - IGNORED', 'ignore');
+                    return true;
+                }
+
+                // Ignore explicitly marked zones
+                if (eventTarget.hasAttribute('data-ignore')) {
+                    log(`❌ Ignored zone: ${eventTarget.getAttribute('data-ignore')}`, 'ignore');
+                    return true;
+                }
+
+                // Ignore maintenance elements
+                if (eventTarget.hasAttribute('data-maintenance')) {
+                    log('❌ Under maintenance - IGNORED', 'ignore');
+                    return true;
+                }
+
+                // Check parents for ignore
+                let parent = eventTarget.parentElement;
+                while (parent && parent !== targetNode) {
+                    if (parent.hasAttribute('data-ignore')) {
+                        log(`❌ Ignored parent found: ${parent.getAttribute('data-ignore')}`, 'ignore');
+                        return true;
+                    }
+                    parent = parent.parentElement;
+                }
+
+                log('✅ No ignore rule - NOT IGNORED');
+                return false;
+            },
+            
+            listeners: {
+                start: function(event) {
+                    log('🚀 Drag started', 'allow');
+                    event.target.style.opacity = 0.8;
+                    event.target.style.transform += ' scale(1.02) rotate(1deg)';
+                    event.target.style.boxShadow = '0 10px 20px rgba(0,0,0,0.3)';
+                },
+                move: dragMoveListener,
+                end: function(event) {
+                    log('🏁 Drag ended', 'info');
+                    event.target.style.opacity = '';
+                    event.target.style.transform = event.target.style.transform
+                        .replace(' scale(1.02)', '')
+                        .replace(' rotate(1deg)', '');
+                    event.target.style.boxShadow = '';
+                }
+            }
+        });
+
+        // Configuration for role-based draggable
+        interact('#role-permissions').draggable({
+            allowFrom: function(targetNode, eventTarget) {
+                // Always allow handle
+                if (eventTarget.classList.contains('drag-handle')) {
+                    return true;
+                }
+
+                // Check minimum role requirements
+                const minRole = eventTarget.getAttribute('data-min-role') || 
+                               eventTarget.closest('[data-min-role]')?.getAttribute('data-min-role');
+                
+                if (minRole) {
+                    const allowed = checkRolePermission(currentRole, minRole);
+                    log(`${allowed ? '✅' : '❌'} Role ${currentRole} for ${minRole} zone: ${allowed ? 'ALLOWED' : 'DENIED'}`, allowed ? 'allow' : 'ignore');
+                    return allowed;
+                }
+
+                return false;
+            },
+
+            ignoreFrom: function(targetNode, eventTarget) {
+                // Ignore forms
+                if (['INPUT', 'TEXTAREA', 'SELECT'].includes(eventTarget.tagName)) {
+                    return true;
+                }
+
+                // Ignore sensitive data
+                if (eventTarget.hasAttribute('data-ignore') && 
+                    eventTarget.getAttribute('data-ignore') === 'sensitive') {
+                    log('❌ Sensitive data - ALWAYS IGNORED', 'ignore');
+                    return true;
+                }
+
+                return false;
+            },
+            
+            listeners: {
+                start: function(event) {
+                    event.target.style.opacity = 0.8;
+                    event.target.style.filter = 'brightness(1.1)';
+                },
+                move: dragMoveListener,
+                end: function(event) {
+                    event.target.style.opacity = '';
+                    event.target.style.filter = '';
+                }
+            }
+        });
+
+        function checkRolePermission(userRole, requiredRole) {
+            const hierarchy = { user: 1, admin: 2 };
+            return (hierarchy[userRole] || 0) >= (hierarchy[requiredRole] || 0);
+        }
+
+        function dragMoveListener(event) {
+            var target = event.target;
+            var x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
+            var y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+
+            target.style.transform = target.style.transform.replace(/translate\([^)]+\)/g, '') + 
+                                   ` translate(${x}px, ${y}px)`;
+            target.setAttribute('data-x', x);
+            target.setAttribute('data-y', y);
+        }
+
+        // Initial log
+        log('🎯 allowFrom/ignoreFrom callback system initialized');
+        log(`👤 Current role: ${currentRole}`);
+    </script>
+</body>
+</html>

--- a/examples/ignoreFrom-callback/index.html
+++ b/examples/ignoreFrom-callback/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>InteractJS - ignoreFrom Callback Example</title>
+    <style>
+        .draggable {
+            width: 200px;
+            height: 150px;
+            background: #4f9;
+            border: 2px solid #333;
+            margin: 20px;
+            padding: 10px;
+            cursor: move;
+            border-radius: 5px;
+        }
+
+        .no-drag {
+            background: #f94;
+            padding: 5px;
+            margin: 5px 0;
+            border-radius: 3px;
+        }
+
+        input, textarea {
+            width: 100%;
+            margin: 5px 0;
+            padding: 5px;
+        }
+
+        .drag-handle {
+            background: #333;
+            color: white;
+            padding: 5px;
+            margin-bottom: 10px;
+            cursor: move;
+        }
+
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+        }
+
+        h1 {
+            color: #333;
+        }
+
+        .info {
+            background: #e3f2fd;
+            padding: 10px;
+            border-radius: 5px;
+            margin-bottom: 20px;
+        }
+    </style>
+</head>
+<body>
+    <h1>InteractJS - ignoreFrom avec fonction callback</h1>
+    
+    <div class="info">
+        <p>Cet exemple montre comment utiliser une fonction callback avec l'option <code>ignoreFrom</code>.</p>
+        <p>Essayez de faire glisser les éléments ci-dessous. Certaines zones sont configurées pour être ignorées.</p>
+    </div>
+
+    <div class="draggable" id="basic-draggable">
+        <div class="drag-handle">✋ Poignée de glissement</div>
+        <p>Zone draggable basique</p>
+        <div class="no-drag">⛔ Zone ignorée (no-drag)</div>
+        <input type="text" placeholder="Input ignoré automatiquement">
+    </div>
+
+    <div class="draggable" id="advanced-draggable">
+        <div class="drag-handle">✋ Drag Handle</div>
+        <p>Zone draggable avec logique avancée</p>
+        <div data-ignore="true" style="background: #ff9; padding: 5px; margin: 5px 0;">
+            📝 Zone avec data-ignore (ignorée)
+        </div>
+        <textarea placeholder="TextArea ignoré automatiquement"></textarea>
+        <button type="button">Bouton normal (draggable)</button>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
+    <script>
+        // Configuration avec callback function
+        interact('.draggable').draggable({
+            // Fonction callback pour ignoreFrom
+            ignoreFrom: function(targetNode, eventTarget) {
+                // Ignorer les inputs et textareas
+                if (eventTarget.tagName === 'INPUT' || eventTarget.tagName === 'TEXTAREA') {
+                    console.log('Ignoré: element input/textarea');
+                    return true;
+                }
+                
+                // Ignorer les éléments avec data-ignore
+                if (eventTarget.hasAttribute && eventTarget.hasAttribute('data-ignore')) {
+                    console.log('Ignoré: élément avec data-ignore');
+                    return true;
+                }
+                
+                // Ignorer les éléments avec classe 'no-drag' ou leurs enfants
+                let element = eventTarget;
+                while (element && element !== targetNode) {
+                    if (element.classList && element.classList.contains('no-drag')) {
+                        console.log('Ignoré: élément ou parent avec classe no-drag');
+                        return true;
+                    }
+                    element = element.parentElement;
+                }
+                
+                console.log('Pas ignoré: début du drag autorisé');
+                return false;
+            },
+            
+            listeners: {
+                start: function(event) {
+                    console.log('Début du drag', event.target.id);
+                    event.target.style.opacity = 0.8;
+                },
+                move: function(event) {
+                    var target = event.target;
+                    var x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx;
+                    var y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+
+                    target.style.transform = 'translate(' + x + 'px, ' + y + 'px)';
+                    target.setAttribute('data-x', x);
+                    target.setAttribute('data-y', y);
+                },
+                end: function(event) {
+                    console.log('Fin du drag', event.target.id);
+                    event.target.style.opacity = '';
+                }
+            }
+        });
+    </script>
+</body>
+</html>

--- a/examples/ignoreFrom-callback/index.html
+++ b/examples/ignoreFrom-callback/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -55,65 +55,65 @@
     </style>
 </head>
 <body>
-    <h1>InteractJS - ignoreFrom avec fonction callback</h1>
+    <h1>InteractJS - ignoreFrom with Callback Function</h1>
     
     <div class="info">
-        <p>Cet exemple montre comment utiliser une fonction callback avec l'option <code>ignoreFrom</code>.</p>
-        <p>Essayez de faire glisser les éléments ci-dessous. Certaines zones sont configurées pour être ignorées.</p>
+        <p>This example shows how to use a callback function with the <code>ignoreFrom</code> option.</p>
+        <p>Try dragging the elements below. Some areas are configured to be ignored.</p>
     </div>
 
     <div class="draggable" id="basic-draggable">
-        <div class="drag-handle">✋ Poignée de glissement</div>
-        <p>Zone draggable basique</p>
-        <div class="no-drag">⛔ Zone ignorée (no-drag)</div>
-        <input type="text" placeholder="Input ignoré automatiquement">
+        <div class="drag-handle">✋ Drag Handle</div>
+        <p>Basic draggable area</p>
+        <div class="no-drag">⛔ Ignored zone (no-drag class)</div>
+        <input type="text" placeholder="Input automatically ignored">
     </div>
 
     <div class="draggable" id="advanced-draggable">
         <div class="drag-handle">✋ Drag Handle</div>
-        <p>Zone draggable avec logique avancée</p>
+        <p>Draggable area with advanced logic</p>
         <div data-ignore="true" style="background: #ff9; padding: 5px; margin: 5px 0;">
-            📝 Zone avec data-ignore (ignorée)
+            📝 Zone with data-ignore (ignored)
         </div>
-        <textarea placeholder="TextArea ignoré automatiquement"></textarea>
-        <button type="button">Bouton normal (draggable)</button>
+        <textarea placeholder="TextArea automatically ignored"></textarea>
+        <button type="button">Normal button (draggable)</button>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
     <script>
-        // Configuration avec callback function
+        // Configuration with callback function
         interact('.draggable').draggable({
-            // Fonction callback pour ignoreFrom
+            // Callback function for ignoreFrom
             ignoreFrom: function(targetNode, eventTarget) {
-                // Ignorer les inputs et textareas
+                // Ignore inputs and textareas
                 if (eventTarget.tagName === 'INPUT' || eventTarget.tagName === 'TEXTAREA') {
-                    console.log('Ignoré: element input/textarea');
+                    console.log('Ignored: input/textarea element');
                     return true;
                 }
                 
-                // Ignorer les éléments avec data-ignore
+                // Ignore elements with data-ignore attribute
                 if (eventTarget.hasAttribute && eventTarget.hasAttribute('data-ignore')) {
-                    console.log('Ignoré: élément avec data-ignore');
+                    console.log('Ignored: element with data-ignore');
                     return true;
                 }
                 
-                // Ignorer les éléments avec classe 'no-drag' ou leurs enfants
+                // Ignore elements with 'no-drag' class or their children
                 let element = eventTarget;
                 while (element && element !== targetNode) {
                     if (element.classList && element.classList.contains('no-drag')) {
-                        console.log('Ignoré: élément ou parent avec classe no-drag');
+                        console.log('Ignored: element or parent with no-drag class');
                         return true;
                     }
                     element = element.parentElement;
                 }
                 
-                console.log('Pas ignoré: début du drag autorisé');
+                console.log('Not ignored: drag start allowed');
                 return false;
             },
             
             listeners: {
                 start: function(event) {
-                    console.log('Début du drag', event.target.id);
+                    console.log('Drag start', event.target.id);
                     event.target.style.opacity = 0.8;
                 },
                 move: function(event) {
@@ -126,7 +126,7 @@
                     target.setAttribute('data-y', y);
                 },
                 end: function(event) {
-                    console.log('Fin du drag', event.target.id);
+                    console.log('Drag end', event.target.id);
                     event.target.style.opacity = '';
                 }
             }

--- a/examples/ignoreFrom-callback/test.js
+++ b/examples/ignoreFrom-callback/test.js
@@ -1,0 +1,60 @@
+// Test simple pour vérifier que la nouvelle fonctionnalité compile
+// et fonctionne avec la syntaxe JavaScript moderne
+
+// Simuler un environnement interactjs
+const interact = require('../../packages/interactjs/index.ts');
+
+// Test 1: Usage avec string (fonctionnalité existante)
+const configWithString = {
+    ignoreFrom: '.ignore-class',
+    listeners: {
+        move: (event) => console.log('move')
+    }
+};
+
+// Test 2: Usage avec fonction callback (nouvelle fonctionnalité)
+const configWithCallback = {
+    ignoreFrom: function(targetNode, eventTarget) {
+        // Logique personnalisée
+        if (eventTarget instanceof Element) {
+            return eventTarget.hasAttribute('data-ignore');
+        }
+        return false;
+    },
+    listeners: {
+        move: (event) => console.log('callback move')
+    }
+};
+
+// Test 3: Usage avec fonction callback plus complexe
+const configWithComplexCallback = {
+    ignoreFrom: (targetNode, eventTarget) => {
+        if (eventTarget instanceof Element) {
+            // Ignorer les inputs
+            if (eventTarget.tagName === 'INPUT' || eventTarget.tagName === 'TEXTAREA') {
+                return true;
+            }
+            
+            // Ignorer si parent a classe 'no-drag'
+            let parent = eventTarget.parentElement;
+            while (parent && parent !== targetNode) {
+                if (parent.classList && parent.classList.contains('no-drag')) {
+                    return true;
+                }
+                parent = parent.parentElement;
+            }
+        }
+        return false;
+    }
+};
+
+console.log('Configurations créées avec succès:');
+console.log('- Config avec string:', typeof configWithString.ignoreFrom);
+console.log('- Config avec callback:', typeof configWithCallback.ignoreFrom);
+console.log('- Config avec callback complexe:', typeof configWithComplexCallback.ignoreFrom);
+
+module.exports = {
+    configWithString,
+    configWithCallback,
+    configWithComplexCallback
+};

--- a/packages/@interactjs/auto-start/base.ts
+++ b/packages/@interactjs/auto-start/base.ts
@@ -59,7 +59,7 @@ declare module '@interactjs/core/options' {
     manualStart?: boolean
     max?: number
     maxPerElement?: number
-    allowFrom?: string | Element
+    allowFrom?: string | Element | ((targetNode: Node, eventTarget: Node) => boolean)
     ignoreFrom?: string | Element | ((targetNode: Node, eventTarget: Node) => boolean)
     cursorChecker?: CursorChecker
 

--- a/packages/@interactjs/auto-start/base.ts
+++ b/packages/@interactjs/auto-start/base.ts
@@ -60,7 +60,7 @@ declare module '@interactjs/core/options' {
     max?: number
     maxPerElement?: number
     allowFrom?: string | Element
-    ignoreFrom?: string | Element
+    ignoreFrom?: string | Element | ((targetNode: Node, eventTarget: Node) => boolean)
     cursorChecker?: CursorChecker
 
     // only allow left button by default

--- a/packages/@interactjs/core/Interactable.allowFrom.spec.ts
+++ b/packages/@interactjs/core/Interactable.allowFrom.spec.ts
@@ -1,4 +1,4 @@
-import { MockInteractable } from '@interactjs/core/tests/_helpers'
+import * as helpers from '@interactjs/core/tests/_helpers'
 
 import type { Interactable } from './Interactable'
 
@@ -8,9 +8,6 @@ describe('Interactable.testAllow with callback function', () => {
   let eventTarget: HTMLElement
 
   beforeEach(() => {
-    // Create a mock interactable
-    interactable = new MockInteractable() as any
-
     // Create DOM elements for testing
     targetNode = document.createElement('div')
     targetNode.className = 'target'
@@ -19,6 +16,10 @@ describe('Interactable.testAllow with callback function', () => {
     eventTarget.className = 'event-target'
 
     targetNode.appendChild(eventTarget)
+
+    // Create interactable using testEnv
+    const { interactable: testInteractable } = helpers.testEnv({ target: targetNode })
+    interactable = testInteractable
   })
 
   test('should work with string selector (existing functionality)', () => {
@@ -38,7 +39,7 @@ describe('Interactable.testAllow with callback function', () => {
   })
 
   test('should work with callback function returning true', () => {
-    const allowFrom = (targetNode: Node, eventTarget: Node) => {
+    const allowFrom = (_targetNode: Node, eventTarget: Node) => {
       return eventTarget instanceof Element && eventTarget.hasAttribute('data-allow')
     }
 
@@ -49,7 +50,7 @@ describe('Interactable.testAllow with callback function', () => {
   })
 
   test('should work with callback function returning false', () => {
-    const allowFrom = (targetNode: Node, eventTarget: Node) => {
+    const allowFrom = (_targetNode: Node, eventTarget: Node) => {
       return eventTarget instanceof Element && eventTarget.hasAttribute('data-allow')
     }
 
@@ -60,7 +61,7 @@ describe('Interactable.testAllow with callback function', () => {
   })
 
   test('should work with complex callback logic for drag handles', () => {
-    const allowFrom = (targetNode: Node, eventTarget: Node) => {
+    const allowFrom = (_targetNode: Node, eventTarget: Node) => {
       if (eventTarget instanceof Element) {
         // Only allow dragging from elements with 'drag-handle' class
         if (eventTarget.classList.contains('drag-handle')) {
@@ -129,7 +130,7 @@ describe('Interactable.testAllow with callback function', () => {
   })
 
   test('should work with role-based access control', () => {
-    const allowFrom = (targetNode: Node, eventTarget: Node) => {
+    const allowFrom = (_targetNode: Node, eventTarget: Node) => {
       if (eventTarget instanceof Element) {
         const role = eventTarget.getAttribute('data-role')
         const allowedRoles = ['admin', 'editor']

--- a/packages/@interactjs/core/Interactable.allowFrom.spec.ts
+++ b/packages/@interactjs/core/Interactable.allowFrom.spec.ts
@@ -1,0 +1,156 @@
+import { MockInteractable } from '@interactjs/core/tests/_helpers'
+
+import type { Interactable } from './Interactable'
+
+describe('Interactable.testAllow with callback function', () => {
+  let interactable: Interactable
+  let targetNode: HTMLElement
+  let eventTarget: HTMLElement
+
+  beforeEach(() => {
+    // Create a mock interactable
+    interactable = new MockInteractable() as any
+
+    // Create DOM elements for testing
+    targetNode = document.createElement('div')
+    targetNode.className = 'target'
+
+    eventTarget = document.createElement('span')
+    eventTarget.className = 'event-target'
+
+    targetNode.appendChild(eventTarget)
+  })
+
+  test('should work with string selector (existing functionality)', () => {
+    const allowFrom = '.allow-class'
+    eventTarget.className = 'allow-class'
+
+    const result = interactable.testAllow(allowFrom, targetNode, eventTarget)
+    expect(result).toBe(true)
+  })
+
+  test('should work with element (existing functionality)', () => {
+    const allowElement = document.createElement('div')
+    allowElement.appendChild(eventTarget)
+
+    const result = interactable.testAllow(allowElement, targetNode, eventTarget)
+    expect(result).toBe(true)
+  })
+
+  test('should work with callback function returning true', () => {
+    const allowFrom = (targetNode: Node, eventTarget: Node) => {
+      return eventTarget instanceof Element && eventTarget.hasAttribute('data-allow')
+    }
+
+    eventTarget.setAttribute('data-allow', 'true')
+
+    const result = interactable.testAllow(allowFrom, targetNode, eventTarget)
+    expect(result).toBe(true)
+  })
+
+  test('should work with callback function returning false', () => {
+    const allowFrom = (targetNode: Node, eventTarget: Node) => {
+      return eventTarget instanceof Element && eventTarget.hasAttribute('data-allow')
+    }
+
+    // No data-allow attribute, so should return false
+
+    const result = interactable.testAllow(allowFrom, targetNode, eventTarget)
+    expect(result).toBe(false)
+  })
+
+  test('should work with complex callback logic for drag handles', () => {
+    const allowFrom = (targetNode: Node, eventTarget: Node) => {
+      if (eventTarget instanceof Element) {
+        // Only allow dragging from elements with 'drag-handle' class
+        if (eventTarget.classList.contains('drag-handle')) {
+          return true
+        }
+
+        // Or allow dragging from specific data attributes
+        if (eventTarget.hasAttribute('data-draggable')) {
+          return true
+        }
+
+        // Check parent elements for drag handle
+        let parent = eventTarget.parentElement
+        while (parent && parent !== targetNode) {
+          if (parent.classList.contains('drag-handle')) {
+            return true
+          }
+          parent = parent.parentElement
+        }
+      }
+      return false
+    }
+
+    // Test with drag handle element
+    const handleElement = document.createElement('div')
+    handleElement.className = 'drag-handle'
+    targetNode.appendChild(handleElement)
+
+    let result = interactable.testAllow(allowFrom, targetNode, handleElement)
+    expect(result).toBe(true)
+
+    // Test with element having data-draggable
+    const draggableElement = document.createElement('span')
+    draggableElement.setAttribute('data-draggable', 'true')
+    targetNode.appendChild(draggableElement)
+
+    result = interactable.testAllow(allowFrom, targetNode, draggableElement)
+    expect(result).toBe(true)
+
+    // Test with child of drag handle
+    const childElement = document.createElement('span')
+    handleElement.appendChild(childElement)
+
+    result = interactable.testAllow(allowFrom, targetNode, childElement)
+    expect(result).toBe(true)
+
+    // Test with normal element (should not allow)
+    const normalElement = document.createElement('div')
+    targetNode.appendChild(normalElement)
+
+    result = interactable.testAllow(allowFrom, targetNode, normalElement)
+    expect(result).toBe(false)
+  })
+
+  test('should return true for undefined allowFrom (default behavior)', () => {
+    const result = interactable.testAllow(undefined, targetNode, eventTarget)
+    expect(result).toBe(true)
+  })
+
+  test('should return false for non-element eventTarget', () => {
+    const allowFrom = () => true
+    const textNode = document.createTextNode('text')
+
+    const result = interactable.testAllow(allowFrom, targetNode, textNode)
+    expect(result).toBe(false)
+  })
+
+  test('should work with role-based access control', () => {
+    const allowFrom = (targetNode: Node, eventTarget: Node) => {
+      if (eventTarget instanceof Element) {
+        const role = eventTarget.getAttribute('data-role')
+        const allowedRoles = ['admin', 'editor']
+        return allowedRoles.includes(role || '')
+      }
+      return false
+    }
+
+    // Test with allowed role
+    eventTarget.setAttribute('data-role', 'admin')
+    let result = interactable.testAllow(allowFrom, targetNode, eventTarget)
+    expect(result).toBe(true)
+
+    // Test with forbidden role
+    eventTarget.setAttribute('data-role', 'viewer')
+    result = interactable.testAllow(allowFrom, targetNode, eventTarget)
+    expect(result).toBe(false)
+
+    // Test with no role
+    eventTarget.removeAttribute('data-role')
+    result = interactable.testAllow(allowFrom, targetNode, eventTarget)
+    expect(result).toBe(false)
+  })
+})

--- a/packages/@interactjs/core/Interactable.ignoreFrom.spec.ts
+++ b/packages/@interactjs/core/Interactable.ignoreFrom.spec.ts
@@ -1,5 +1,6 @@
+import * as helpers from '@interactjs/core/tests/_helpers'
+
 import type { Interactable } from './Interactable'
-import { MockInteractable } from '@interactjs/core/tests/_helpers'
 
 describe('Interactable.testIgnore with callback function', () => {
   let interactable: Interactable
@@ -7,17 +8,18 @@ describe('Interactable.testIgnore with callback function', () => {
   let eventTarget: HTMLElement
 
   beforeEach(() => {
-    // Create a mock interactable
-    interactable = new MockInteractable() as any
-
     // Create DOM elements for testing
     targetNode = document.createElement('div')
     targetNode.className = 'target'
-    
+
     eventTarget = document.createElement('span')
     eventTarget.className = 'event-target'
-    
+
     targetNode.appendChild(eventTarget)
+
+    // Create interactable using testEnv
+    const { interactable: testInteractable } = helpers.testEnv({ target: targetNode })
+    interactable = testInteractable
   })
 
   test('should work with string selector (existing functionality)', () => {
@@ -37,7 +39,7 @@ describe('Interactable.testIgnore with callback function', () => {
   })
 
   test('should work with callback function returning true', () => {
-    const ignoreFrom = (targetNode: Node, eventTarget: Node) => {
+    const ignoreFrom = (_targetNode: Node, eventTarget: Node) => {
       return eventTarget instanceof Element && eventTarget.hasAttribute('data-ignore')
     }
 
@@ -48,7 +50,7 @@ describe('Interactable.testIgnore with callback function', () => {
   })
 
   test('should work with callback function returning false', () => {
-    const ignoreFrom = (targetNode: Node, eventTarget: Node) => {
+    const ignoreFrom = (_targetNode: Node, eventTarget: Node) => {
       return eventTarget instanceof Element && eventTarget.hasAttribute('data-ignore')
     }
 
@@ -59,7 +61,7 @@ describe('Interactable.testIgnore with callback function', () => {
   })
 
   test('should work with complex callback logic', () => {
-    const ignoreFrom = (targetNode: Node, eventTarget: Node) => {
+    const ignoreFrom = (_targetNode: Node, eventTarget: Node) => {
       if (eventTarget instanceof Element) {
         // Ignore input elements
         if (eventTarget.tagName === 'INPUT' || eventTarget.tagName === 'TEXTAREA') {
@@ -81,7 +83,7 @@ describe('Interactable.testIgnore with callback function', () => {
     // Test with input element
     const inputElement = document.createElement('input')
     targetNode.appendChild(inputElement)
-    
+
     let result = interactable.testIgnore(ignoreFrom, targetNode, inputElement)
     expect(result).toBe(true)
 

--- a/packages/@interactjs/core/Interactable.ignoreFrom.spec.ts
+++ b/packages/@interactjs/core/Interactable.ignoreFrom.spec.ts
@@ -1,0 +1,118 @@
+import type { Interactable } from './Interactable'
+import { MockInteractable } from '@interactjs/core/tests/_helpers'
+
+describe('Interactable.testIgnore with callback function', () => {
+  let interactable: Interactable
+  let targetNode: HTMLElement
+  let eventTarget: HTMLElement
+
+  beforeEach(() => {
+    // Create a mock interactable
+    interactable = new MockInteractable() as any
+
+    // Create DOM elements for testing
+    targetNode = document.createElement('div')
+    targetNode.className = 'target'
+    
+    eventTarget = document.createElement('span')
+    eventTarget.className = 'event-target'
+    
+    targetNode.appendChild(eventTarget)
+  })
+
+  test('should work with string selector (existing functionality)', () => {
+    const ignoreFrom = '.ignore-class'
+    eventTarget.className = 'ignore-class'
+
+    const result = interactable.testIgnore(ignoreFrom, targetNode, eventTarget)
+    expect(result).toBe(true)
+  })
+
+  test('should work with element (existing functionality)', () => {
+    const ignoreElement = document.createElement('div')
+    ignoreElement.appendChild(eventTarget)
+
+    const result = interactable.testIgnore(ignoreElement, targetNode, eventTarget)
+    expect(result).toBe(true)
+  })
+
+  test('should work with callback function returning true', () => {
+    const ignoreFrom = (targetNode: Node, eventTarget: Node) => {
+      return eventTarget instanceof Element && eventTarget.hasAttribute('data-ignore')
+    }
+
+    eventTarget.setAttribute('data-ignore', 'true')
+
+    const result = interactable.testIgnore(ignoreFrom, targetNode, eventTarget)
+    expect(result).toBe(true)
+  })
+
+  test('should work with callback function returning false', () => {
+    const ignoreFrom = (targetNode: Node, eventTarget: Node) => {
+      return eventTarget instanceof Element && eventTarget.hasAttribute('data-ignore')
+    }
+
+    // No data-ignore attribute, so should return false
+
+    const result = interactable.testIgnore(ignoreFrom, targetNode, eventTarget)
+    expect(result).toBe(false)
+  })
+
+  test('should work with complex callback logic', () => {
+    const ignoreFrom = (targetNode: Node, eventTarget: Node) => {
+      if (eventTarget instanceof Element) {
+        // Ignore input elements
+        if (eventTarget.tagName === 'INPUT' || eventTarget.tagName === 'TEXTAREA') {
+          return true
+        }
+
+        // Ignore elements with no-drag class in parent chain
+        let parent = eventTarget.parentElement
+        while (parent && parent !== targetNode) {
+          if (parent.classList.contains('no-drag')) {
+            return true
+          }
+          parent = parent.parentElement
+        }
+      }
+      return false
+    }
+
+    // Test with input element
+    const inputElement = document.createElement('input')
+    targetNode.appendChild(inputElement)
+    
+    let result = interactable.testIgnore(ignoreFrom, targetNode, inputElement)
+    expect(result).toBe(true)
+
+    // Test with element having no-drag parent
+    const noDragParent = document.createElement('div')
+    noDragParent.className = 'no-drag'
+    const childElement = document.createElement('span')
+    noDragParent.appendChild(childElement)
+    targetNode.appendChild(noDragParent)
+
+    result = interactable.testIgnore(ignoreFrom, targetNode, childElement)
+    expect(result).toBe(true)
+
+    // Test with normal element (should not ignore)
+    const normalElement = document.createElement('div')
+    targetNode.appendChild(normalElement)
+
+    result = interactable.testIgnore(ignoreFrom, targetNode, normalElement)
+    expect(result).toBe(false)
+  })
+
+  test('should return false for undefined ignoreFrom', () => {
+    const result = interactable.testIgnore(undefined, targetNode, eventTarget)
+    expect(result).toBe(false)
+  })
+
+  test('should return false for non-element eventTarget', () => {
+    const ignoreFrom = () => true
+    const textNode = document.createTextNode('text')
+
+    const result = interactable.testIgnore(ignoreFrom, targetNode, textNode)
+    expect(result).toBe(false)
+  })
+})

--- a/packages/@interactjs/core/Interactable.ts
+++ b/packages/@interactjs/core/Interactable.ts
@@ -1,14 +1,4 @@
 /* eslint-disable no-dupe-class-members */
-import * as arr from '@interactjs/utils/arr'
-import browser from '@interactjs/utils/browser'
-import clone from '@interactjs/utils/clone'
-import { getElementRect, matchesUpTo, nodeContains, trySelector } from '@interactjs/utils/domUtils'
-import extend from '@interactjs/utils/extend'
-import is from '@interactjs/utils/is'
-import isNonNativeEvent from '@interactjs/utils/isNonNativeEvent'
-import normalizeListeners from '@interactjs/utils/normalizeListeners'
-import { getWindow } from '@interactjs/utils/window'
-
 import type { Scope } from '@interactjs/core/scope'
 import type {
   ActionMap,
@@ -23,11 +13,22 @@ import type {
   OrBoolean,
   Target,
 } from '@interactjs/core/types'
+import * as arr from '@interactjs/utils/arr'
+import browser from '@interactjs/utils/browser'
+import clone from '@interactjs/utils/clone'
+import { getElementRect, matchesUpTo, nodeContains, trySelector } from '@interactjs/utils/domUtils'
+import extend from '@interactjs/utils/extend'
+import is from '@interactjs/utils/is'
+import isNonNativeEvent from '@interactjs/utils/isNonNativeEvent'
+import normalizeListeners from '@interactjs/utils/normalizeListeners'
+import { getWindow } from '@interactjs/utils/window'
+
 
 import { Eventable } from './Eventable'
 import type { ActionDefaults, Defaults, OptionsArg, PerActionDefaults, Options } from './options'
 
 type IgnoreValue = string | Element | boolean | ((targetNode: Node, eventTarget: Node) => boolean)
+type AllowValue = string | Element | boolean | ((targetNode: Node, eventTarget: Node) => boolean)
 type DeltaSource = 'page' | 'client'
 
 const enum OnOffMethod {
@@ -291,7 +292,7 @@ export class Interactable implements Partial<Eventable> {
   /** @internal */
   testIgnoreAllow(
     this: Interactable,
-    options: { ignoreFrom?: IgnoreValue; allowFrom?: IgnoreValue },
+    options: { ignoreFrom?: IgnoreValue; allowFrom?: AllowValue },
     targetNode: Node,
     eventTarget: Node,
   ) {
@@ -302,7 +303,7 @@ export class Interactable implements Partial<Eventable> {
   }
 
   /** @internal */
-  testAllow(this: Interactable, allowFrom: IgnoreValue | undefined, targetNode: Node, element: Node) {
+  testAllow(this: Interactable, allowFrom: AllowValue | undefined, targetNode: Node, element: Node) {
     if (!allowFrom) {
       return true
     }
@@ -315,6 +316,8 @@ export class Interactable implements Partial<Eventable> {
       return matchesUpTo(element, allowFrom, targetNode)
     } else if (is.element(allowFrom)) {
       return nodeContains(allowFrom, element)
+    } else if (is.function(allowFrom)) {
+      return allowFrom(targetNode, element)
     }
 
     return false

--- a/packages/@interactjs/core/Interactable.ts
+++ b/packages/@interactjs/core/Interactable.ts
@@ -1,4 +1,14 @@
 /* eslint-disable no-dupe-class-members */
+import * as arr from '@interactjs/utils/arr'
+import browser from '@interactjs/utils/browser'
+import clone from '@interactjs/utils/clone'
+import { getElementRect, matchesUpTo, nodeContains, trySelector } from '@interactjs/utils/domUtils'
+import extend from '@interactjs/utils/extend'
+import is from '@interactjs/utils/is'
+import isNonNativeEvent from '@interactjs/utils/isNonNativeEvent'
+import normalizeListeners from '@interactjs/utils/normalizeListeners'
+import { getWindow } from '@interactjs/utils/window'
+
 import type { Scope } from '@interactjs/core/scope'
 import type {
   ActionMap,
@@ -13,16 +23,6 @@ import type {
   OrBoolean,
   Target,
 } from '@interactjs/core/types'
-import * as arr from '@interactjs/utils/arr'
-import browser from '@interactjs/utils/browser'
-import clone from '@interactjs/utils/clone'
-import { getElementRect, matchesUpTo, nodeContains, trySelector } from '@interactjs/utils/domUtils'
-import extend from '@interactjs/utils/extend'
-import is from '@interactjs/utils/is'
-import isNonNativeEvent from '@interactjs/utils/isNonNativeEvent'
-import normalizeListeners from '@interactjs/utils/normalizeListeners'
-import { getWindow } from '@interactjs/utils/window'
-
 
 import { Eventable } from './Eventable'
 import type { ActionDefaults, Defaults, OptionsArg, PerActionDefaults, Options } from './options'
@@ -316,7 +316,7 @@ export class Interactable implements Partial<Eventable> {
       return matchesUpTo(element, allowFrom, targetNode)
     } else if (is.element(allowFrom)) {
       return nodeContains(allowFrom, element)
-    } else if (is.function(allowFrom)) {
+    } else if (is.func(allowFrom)) {
       return allowFrom(targetNode, element)
     }
 
@@ -333,7 +333,7 @@ export class Interactable implements Partial<Eventable> {
       return matchesUpTo(element, ignoreFrom, targetNode)
     } else if (is.element(ignoreFrom)) {
       return nodeContains(ignoreFrom, element)
-    } else if (is.function(ignoreFrom)) {
+    } else if (is.func(ignoreFrom)) {
       return ignoreFrom(targetNode, element)
     }
 

--- a/packages/@interactjs/core/Interactable.ts
+++ b/packages/@interactjs/core/Interactable.ts
@@ -27,7 +27,7 @@ import type {
 import { Eventable } from './Eventable'
 import type { ActionDefaults, Defaults, OptionsArg, PerActionDefaults, Options } from './options'
 
-type IgnoreValue = string | Element | boolean
+type IgnoreValue = string | Element | boolean | ((targetNode: Node, eventTarget: Node) => boolean)
 type DeltaSource = 'page' | 'client'
 
 const enum OnOffMethod {
@@ -330,6 +330,8 @@ export class Interactable implements Partial<Eventable> {
       return matchesUpTo(element, ignoreFrom, targetNode)
     } else if (is.element(ignoreFrom)) {
       return nodeContains(ignoreFrom, element)
+    } else if (is.function(ignoreFrom)) {
+      return ignoreFrom(targetNode, element)
     }
 
     return false

--- a/packages/@interactjs/core/options.ts
+++ b/packages/@interactjs/core/options.ts
@@ -20,7 +20,7 @@ export interface PerActionDefaults {
   enabled?: boolean
   origin?: Point | string | Element
   listeners?: Listeners
-  allowFrom?: string | Element
+  allowFrom?: string | Element | ((targetNode: Node, eventTarget: Node) => boolean)
   ignoreFrom?: string | Element | ((targetNode: Node, eventTarget: Node) => boolean)
 }
 

--- a/packages/@interactjs/core/options.ts
+++ b/packages/@interactjs/core/options.ts
@@ -21,7 +21,7 @@ export interface PerActionDefaults {
   origin?: Point | string | Element
   listeners?: Listeners
   allowFrom?: string | Element
-  ignoreFrom?: string | Element
+  ignoreFrom?: string | Element | ((targetNode: Node, eventTarget: Node) => boolean)
 }
 
 export type Options = Partial<BaseDefaults> &

--- a/packages/@interactjs/core/types.ts
+++ b/packages/@interactjs/core/types.ts
@@ -122,7 +122,7 @@ export type OriginFunction = (target: Element) => Rect
 
 export interface PointerEventsOptions {
   holdDuration?: number
-  allowFrom?: string
+  allowFrom?: string | Element | ((targetNode: Node, eventTarget: Node) => boolean)
   ignoreFrom?: string | Element | ((targetNode: Node, eventTarget: Node) => boolean)
   origin?: Rect | Point | string | Element | OriginFunction
 }

--- a/packages/@interactjs/core/types.ts
+++ b/packages/@interactjs/core/types.ts
@@ -123,7 +123,7 @@ export type OriginFunction = (target: Element) => Rect
 export interface PointerEventsOptions {
   holdDuration?: number
   allowFrom?: string
-  ignoreFrom?: string
+  ignoreFrom?: string | Element | ((targetNode: Node, eventTarget: Node) => boolean)
   origin?: Rect | Point | string | Element | OriginFunction
 }
 


### PR DESCRIPTION
This pull request enhances interact.js with callback function support for allowFrom and ignoreFrom options, providing developers with powerful programmatic control over interaction permissions.

  Key Features Added

  - Callback Support: Both allowFrom and ignoreFrom now accept callback functions with signature (targetNode: Node, eventTarget: Node) => boolean
  - Enhanced Type Safety: Updated TypeScript definitions across core packages
  - Comprehensive Examples: Added 3 interactive demo pages showcasing different use cases
  - Full Test Coverage: Added test suites for both allowFrom and ignoreFrom callback functionality

  New Examples

  - ignoreFrom-callback/ - Basic callback usage with conditional ignore logic
  - allowFrom-callback/ - Role-based access control demonstration
  - combined-callbacks/ - Advanced example combining both options

  Technical Changes

  - Updated type definitions in @interactjs/core, @interactjs/auto-start, and related packages
  - Enhanced Interactable.testAllow() and Interactable.testIgnore() methods with function support
  - Maintained full backward compatibility with existing string/element selectors

  This enhancement enables sophisticated interaction control scenarios like role-based permissions, conditional drag handles, and complex UI state management while preserving the library's existing API.
